### PR TITLE
Make the package work on Windows

### DIFF
--- a/.github/workflows/l3build.yml
+++ b/.github/workflows/l3build.yml
@@ -30,8 +30,10 @@ jobs:
         shell: pwsh
         run: |
           choco install --yes --no-progress ghostscript
-          $bin = (Get-ChildItem 'C:\Program Files\gs\gs*\bin' -Directory | Select-Object -First 1).FullName
-          Add-Content -Path $env:GITHUB_PATH -Value $bin
+          $gs = Get-ChildItem 'C:\Program Files\gs' -Recurse -Filter gswin64c.exe -ErrorAction SilentlyContinue | Select-Object -First 1
+          if (-not $gs) { throw 'gswin64c.exe not found after install' }
+          Write-Host "Ghostscript at $($gs.DirectoryName)"
+          Add-Content -Path $env:GITHUB_PATH -Value $gs.DirectoryName
       - run: sed -E 's/^(hard|soft)[[:space:]]+//' DEPENDS.txt > .texlive-packages.txt
       - uses: zauguin/install-texlive@v4.4.0
         with:

--- a/.github/workflows/l3build.yml
+++ b/.github/workflows/l3build.yml
@@ -26,8 +26,12 @@ jobs:
         if: matrix.os == 'ubuntu-24.04'
       - run: brew install ghostscript
         if: matrix.os == 'macos-15'
-      - run: choco install --yes --no-progress ghostscript
-        if: matrix.os == 'windows-2025'
+      - if: matrix.os == 'windows-2025'
+        shell: pwsh
+        run: |
+          choco install --yes --no-progress ghostscript
+          $bin = (Get-ChildItem 'C:\Program Files\gs\gs*\bin' -Directory | Select-Object -First 1).FullName
+          Add-Content -Path $env:GITHUB_PATH -Value $bin
       - run: sed -E 's/^(hard|soft)[[:space:]]+//' DEPENDS.txt > .texlive-packages.txt
       - uses: zauguin/install-texlive@v4.4.0
         with:

--- a/.github/workflows/l3build.yml
+++ b/.github/workflows/l3build.yml
@@ -10,25 +10,33 @@ name: l3build
     branches: master
 jobs:
   l3build:
-    timeout-minutes: 15
+    timeout-minutes: 30
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
     env:
       TERM: xterm-256color
     strategy:
       matrix:
-        os: [ubuntu-24.04, macos-15]
+        os: [ubuntu-24.04, macos-15, windows-2025]
     steps:
       - uses: actions/checkout@v4
       - run: sudo apt-get install --yes ghostscript
         if: matrix.os == 'ubuntu-24.04'
       - run: brew install ghostscript
         if: matrix.os == 'macos-15'
+      - run: choco install --yes --no-progress ghostscript
+        if: matrix.os == 'windows-2025'
       - run: sed -E 's/^(hard|soft)[[:space:]]+//' DEPENDS.txt > .texlive-packages.txt
       - uses: zauguin/install-texlive@v4.4.0
         with:
           package_file: .texlive-packages.txt
           texlive_version: 2025
       - run: l3build ctan --show-log-on-error --halt-on-error
+        if: matrix.os != 'windows-2025'
+      - run: l3build doc --halt-on-error
+        if: matrix.os == 'windows-2025'
       - if: failure()
         run: |
           echo '::group::docshots.log'

--- a/.github/workflows/l3build.yml
+++ b/.github/workflows/l3build.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: zauguin/install-texlive@v4.4.0
         with:
           package_file: .texlive-packages.txt
-          texlive_version: 2025
+          texlive_version: 2026
       - run: l3build ctan --show-log-on-error --halt-on-error
         if: matrix.os != 'windows-2025'
       - run: l3build doc --halt-on-error

--- a/docshots.dtx
+++ b/docshots.dtx
@@ -59,14 +59,13 @@
 %
 % \maketitle
 %
-% \textbf{\color{red}NB!}
-% This package does not operate on Windows!
-% The \TeX{} processor must furthermore be invoked with the |--shell-escape| option,
+% The \TeX{} processor must be invoked with the |--shell-escape| option,
 % and the following must be installed on the host system:
 % |pdflatex|,
 % \href{https://www.perl.org}{Perl},
 % \href{https://www.ghostscript.com}{Ghostscript},
 % and \href{https://ctan.org/pkg/pdfcrop}{pdfcrop}.
+% The package operates on Windows as well as on Unix, provided these tools are on the |PATH|.
 
 % \section{Introduction}
 %
@@ -167,7 +166,7 @@ Hello, world!
 %\fi
 
 % \DescribeMacro{gs}
-% The default location of Ghostscript is simply |gs|.
+% The default location of Ghostscript is simply |gs| on Unix and |gswin64c| on Windows.
 % This may be altered by means of the |gs| package option,
 % for example:
 %\iffalse
@@ -478,10 +477,32 @@ Hello, world!
 % \changes{0.0.4}{2022/10/18}{Package options "lstinputlisting" and "inputminted" introduced to enable printing of verbatim text either via listings or minted packages.}
 % \changes{0.0.5}{2022/10/24}{Package option "log" added, which enables detailed logging via exec. By default, there is no logging at all.}
 % \changes{0.2.0}{2022/10/26}{New package option "nocrop" added to allow disabling of "pdfcrop" execution.}
+% We also detect Windows, in order to pick the right default for Ghostscript,
+% and we prepare an expanding variant of the string-replacement command
+% for later use in \docshotAfter:
+% \changes{0.5.0}{2026/07/13}{Windows compatibility: file operations go through Perl, and the "gs" default becomes "gswin64c" on Windows.}
 %    \begin{macrocode}
 \RequirePackage{pgfopts}
 \RequirePackage{ifluatex}
 \RequirePackage{ifxetex}
+\RequirePackage{expl3}
+\newif\ifdocshots@windows
+\ExplSyntaxOn
+\sys_if_platform_windows:TF{\docshots@windowstrue}{\docshots@windowsfalse}
+\cs_generate_variant:Nn \str_replace_all:Nnn { Nne }
+\newcommand\docshots@aftercmd[3]{%
+  \str_set:Nx \l_tmpa_str { \docshots@after }%
+  \str_replace_all:Nne \l_tmpa_str { $1 } { #1 }%
+  \str_replace_all:Nne \l_tmpa_str { $2 } { #2 }%
+  \str_replace_all:Nne \l_tmpa_str { $3 } { #3 }%
+  \cs_set:Npx \docshots@aftersh { \str_use:N \l_tmpa_str }%
+}
+\ExplSyntaxOff
+\ifdocshots@windows
+  \def\docshots@gsdefault{gswin64c}%
+\else
+  \def\docshots@gsdefault{gs}%
+\fi
 \def\docshots@log{}
 \pgfkeys{
   /docshots/.cd,
@@ -499,7 +520,7 @@ Hello, world!
   pdflatex/.store in=\docshots@pdflatex,
   pdflatex/.default=pdflatex,
   gs/.store in=\docshots@gs,
-  gs/.default=gs,
+  gs/.default=\docshots@gsdefault,
   pdfcrop/.store in=\docshots@pdfcrop,
   pdfcrop/.default=pdfcrop,
   margin/.store in=\docshots@margin,
@@ -527,14 +548,17 @@ Hello, world!
 \fi%
 %    \end{macrocode}
 
-% Then, we print the version of |ghostscript| to \TeX{} log:
+% Then, we print the version of |ghostscript| to \TeX{} log, ignoring a
+% failure, since Ghostscript is not strictly required for rendering:
 %    \begin{macrocode}
-\iexec[\docshots@log,quiet]{"\docshots@gs" --version}%
+\iexec[\docshots@log,quiet,ignore]{"\docshots@gs" --version}%
 %    \end{macrocode}
 
-% Then, we make a directory where all temporary files will be kept:
+% Then, we make a directory where all temporary files will be kept. We use
+% Perl instead of |mkdir|, so that the code works on Windows too:
 %    \begin{macrocode}
-\iexec[null]{mkdir -p "\docshots@tmpdir/\jobname"}%
+\iexec[null]{perl -MFile::Path=make_path -e "make_path(shift)"
+  "\docshots@tmpdir/\jobname"}%
 %    \end{macrocode}
 
 % \begin{macro}{\docshots@mdfive}
@@ -578,7 +602,8 @@ Hello, world!
   \IfFileExists{\docshots@tmpdir/\jobname/\hash.pdf}
     {\message{docshots: Won't render,
       the PDF '\docshots@tmpdir/\jobname/\hash.pdf' already exists^^J}}
-    {\iexec[\docshots@log,quiet]{cp "\docshots@tmpdir/\jobname/docshots-temp.tex"
+    {\iexec[\docshots@log,quiet]{perl -MFile::Copy -e "copy(shift,shift) or die q(cannot copy)"
+      "\docshots@tmpdir/\jobname/docshots-temp.tex"
       "\docshots@tmpdir/\jobname/\hash.tex"}%
     \message{docshots: rendering at line no. \the\inputlineno^^J}%
     \foreach \n in {1,...,\docshots@runs}{%
@@ -594,17 +619,19 @@ Hello, world!
       \ifnum\n=1\else%
         \message{docshots: pdflatex run no.\n^^J}%
       \fi%
-      \IfFileExists{\docshots@tmpdir/\jobname/after.sh}
-        {\iexec[\docshots@log,quiet]{chmod a+x
-          "\docshots@tmpdir/\jobname/after.sh"}
-        \iexec[\docshots@log,quiet]{cd "\docshots@tmpdir/\jobname" &&
-          ./after.sh \n\space \hash\space \hash.tex}}
-        {}}}%
 %    \end{macrocode}
-% Here we delete |after.sh| which may exist here after the last
-% compilation of |pdflatex|:
+% If a post-processing command was registered by \docshotAfter, we substitute
+% its |$1|, |$2|, and |$3| placeholders and execute it. There is no shell script
+% and no |chmod|, so the mechanism works on Windows too:
 %    \begin{macrocode}
-  \iexec[\docshots@log,quiet]{rm -f "\docshots@tmpdir/\jobname/after.sh"}
+      \ifdefined\docshots@after%
+        \begingroup%
+          \docshots@aftercmd{\n}{\hash}{\hash.tex}%
+          \iexec[\docshots@log,quiet]{cd "\docshots@tmpdir/\jobname" &&
+            \docshots@aftersh}%
+        \endgroup%
+      \fi}}%
+  \global\let\docshots@after\@undefined%
 %    \end{macrocode}
 % If a cropped version of the PDF with the required name already exists, we ignore this step.
 % Otherwise, we ask |pdfcrop| to crop the PDF:
@@ -678,7 +705,8 @@ Hello, world!
 %    \begin{macrocode}
 \makeatletter
 \newcommand\docshotPrerequisite[1]{
-  \iexec[\docshots@log,quiet]{cp #1 "\docshots@tmpdir/\jobname"}%
+  \iexec[\docshots@log,quiet]{perl -MFile::Copy -e "copy(shift,shift) or die q(cannot copy)"
+    "#1" "\docshots@tmpdir/\jobname/#1"}%
   \message{docshots: File '#1' copied to
     '\docshots@tmpdir/\jobname/#1'^^J}%
 }
@@ -687,14 +715,15 @@ Hello, world!
 % \end{macro}
 
 % \begin{macro}{\docshotAfter}
-% Then, we define |\docshotAfter| command:
+% Then, we define |\docshotAfter| command. Rather than writing a shell script,
+% we merely remember the command as a detokenized string; the |docshot|
+% environment substitutes its placeholders and runs it after each |pdflatex|:
+% \changes{0.5.0}{2026/07/13}{The command is remembered as a string and executed directly, instead of being written to a shell script, for Windows compatibility.}
 %    \begin{macrocode}
 \makeatletter
 \newcommand\docshotAfter[1]{
-  \iexec[\docshots@log,quiet]{/bin/echo -n '\detokenize{#1}'
-    > "\docshots@tmpdir/\jobname/after.sh"}%
-  \message{docshots: File
-    '\docshots@tmpdir/\jobname/after.sh' created^^J}%
+  \xdef\docshots@after{\detokenize{#1}}%
+  \message{docshots: post-processing command '\docshots@after' registered^^J}%
 }
 \makeatother
 %    \end{macrocode}

--- a/docshots.dtx
+++ b/docshots.dtx
@@ -65,6 +65,8 @@
 % \href{https://www.perl.org}{Perl},
 % \href{https://www.ghostscript.com}{Ghostscript},
 % and \href{https://ctan.org/pkg/pdfcrop}{pdfcrop}.
+% The |--shell-escape| option is required because the package launches these
+% external programs from within the \TeX{} run in order to compile and crop each snippet.
 % The package operates on Windows as well as on Unix, provided these tools are on the |PATH|.
 
 % \section{Introduction}
@@ -74,7 +76,7 @@
 % precisely how the entire document will be rendered as a PDF, by means
 % of a subprocess (such as |pdflatex|) that performs the rendering.
 % To the \href{https://tex.stackexchange.com/questions/661027}{author's
-% best} knowledge, no existing package addressed this need; whence the
+% best} knowledge, no existing package addresses this need; hence the
 % present, modest package was devised.
 
 % For instance, the following code:
@@ -119,14 +121,21 @@
 % \end{document}
 % \end{docshot}
 
+% The body of every |docshot| environment must be a complete, self-contained
+% \LaTeX{} document: it begins with |\documentclass|, loads whatever packages it
+% requires, and wraps its content in |\begin{document}| and |\end{document}|. The
+% body is written verbatim to a separate |.tex| file and compiled on its own, exactly
+% as the two examples above demonstrate.
+
 % The figure on the left is produced by a subprocess that executes
-% |pdflatex| upon the |.tex| content extracted from the source file.
+% |pdflatex| on the |.tex| content extracted from the source file.
 % Once the \TeX{} sources have been successfully processed,
 % \href{https://ctan.org/pkg/pdfcrop}{pdfcrop} is invoked to trim the document.
 
 % |pdflatex| is run with the |-interaction=errorstopmode| and |-halt-on-error| options.
 % Consequently, \TeX{} processing halts at the first error encountered. The \TeX{}
-% log should be consulted to ascertain the cause of any failure.
+% log should be consulted to ascertain the cause of any failure; the |log| option,
+% described below, copies the full output of |pdflatex| into that log.
 
 % Whenever text rather than a single figure is to be rendered, the
 % \href{https://ctan.org/pkg/geometry}{geometry} package is recommended for
@@ -141,9 +150,12 @@
 % pessimist'' --- \emph{Mark Twain}
 % \end{document}
 % \end{docshot}
-% The use of |\pagestyle{empty}|, as employed in the preceding docshots, is likewise viable.
+% The use of |\pagestyle{empty}|, as in the preceding docshots, is likewise possible.
 
 % \section{Package Options}
+
+% All options listed below are supplied to the package in the usual way, within the
+% optional argument of |\usepackage[...]{docshots}|.
 
 % \DescribeMacro{pdflatex}
 % The default command-line tool for converting |.tex| into
@@ -247,7 +259,7 @@ Hello, world!
 
 % \DescribeMacro{dtx}
 % Whenever this package is employed within |.dtx| documentation, the |dtx| package option must be added. Under
-% this option, all leading comment symbols are removed from the start of each line:
+% this option, all leading comment symbols (the |%| characters) are removed from the start of each line:
 %\iffalse
 %<*verb>
 %\fi
@@ -286,7 +298,7 @@ Hello, world!
 % \DescribeMacro{small}
 % \DescribeMacro{tiny}
 % The latitude available for formatting verbatim texts is limited; nevertheless, the font
-% may be reduced somewhat by means of the |small| package option, or rendered considerably
+% may be reduced somewhat by means of the |small| package option, or made considerably
 % smaller still by the |tiny| option:
 %\iffalse
 %<*verb>
@@ -367,7 +379,7 @@ Hello, world!
 % \section{Prerequisites}
 
 % \DescribeMacro{\docshotPrerequisite}
-% \changes{0.0.3}{2022/10/14}{The command is added to enable copying of supplementary files into docshots snippets processing directory.}
+% \changes{0.0.3}{2022/10/14}{The command is added to enable copying of supplementary files into the directory where docshot snippets are processed.}
 % Whenever certain files are required to be present alongside the |.tex| snippet during
 % rendering by |pdflatex|, the |\docshotPrerequisite| command may be employed, accepting
 % a single mandatory argument. The argument denotes the name of a file to be copied from
@@ -400,8 +412,8 @@ Hello, world!
 % \DescribeMacro{\docshotAfter}
 % Should some action be required after each |pdflatex| run of a docshot, the
 % |\docshotAfter| command may be placed immediately before the |docshot| environment. For example, when a bibliography file is to remain
-% visible for every snippet and \href{https://ctan.org/pkg/biber}{biber} is to be invoked
-% upon each in order to process citations:
+% available to every snippet and \href{https://ctan.org/pkg/biber}{biber} is to be invoked
+% on each in order to process citations:
 %\iffalse
 %<*verb>
 %\fi
@@ -462,7 +474,7 @@ Hello, world!
 %    \end{macrocode}
 
 % Then, we include \href{https://ctan.org/pkg/graphicx}{graphicx}
-% in order to be able to use |\includegraphics| command:
+% in order to be able to use the |\includegraphics| command:
 %    \begin{macrocode}
 \RequirePackage{graphicx}
 %    \end{macrocode}
@@ -474,7 +486,7 @@ Hello, world!
 %    \end{macrocode}
 
 % Then, we process package options with the help of \href{https://ctan.org/pkg/pgfopts}{pgfopts}:
-% \changes{0.0.4}{2022/10/18}{Package options "lstinputlisting" and "inputminted" introduced to enable printing of verbatim text either via listings or minted packages.}
+% \changes{0.0.4}{2022/10/18}{Package options "lstinputlisting" and "inputminted" introduced to enable printing of verbatim text via either the listings or the minted package.}
 % \changes{0.0.5}{2022/10/24}{Package option "log" added, which enables detailed logging via exec. By default, there is no logging at all.}
 % \changes{0.2.0}{2022/10/26}{New package option "nocrop" added to allow disabling of "pdfcrop" execution.}
 % We also detect Windows, in order to pick the right default for Ghostscript,
@@ -536,19 +548,19 @@ Hello, world!
 \ProcessPgfOptions{/docshots}
 %    \end{macrocode}
 
-% Then, we print the version of |pdflatex| to \TeX{} log:
+% Then, we print the version of |pdflatex| to the \TeX{} log:
 %    \begin{macrocode}
 \iexec[\docshots@log,quiet]{"\docshots@pdflatex" --version}%
 %    \end{macrocode}
 
-% Then, we print the version of \href{https://ctan.org/pkg/pdfcrop}{pdfcrop} to \TeX{} log:
+% Then, we print the version of \href{https://ctan.org/pkg/pdfcrop}{pdfcrop} to the \TeX{} log:
 %    \begin{macrocode}
 \ifdefined\docshots@nocrop\else%
   \iexec[\docshots@log,quiet]{"\docshots@pdfcrop" --version}%
 \fi%
 %    \end{macrocode}
 
-% Then, we print the version of |ghostscript| to \TeX{} log, ignoring a
+% Then, we print the version of |ghostscript| to the \TeX{} log, ignoring a
 % failure, since Ghostscript is not strictly required for rendering:
 %    \begin{macrocode}
 \iexec[\docshots@log,quiet,ignore]{"\docshots@gs" --version}%
@@ -595,7 +607,7 @@ Hello, world!
   \def\hash{\docshots@mdfive{\docshots@tmpdir/\jobname/docshots-temp.tex}}%
 %    \end{macrocode}
 % If the PDF with the required name already exists, we ignore this step.
-% Otherwise, we copy |docshots-temp.tex| into new file and run |pdflatex|:
+% Otherwise, we copy |docshots-temp.tex| into a new file and run |pdflatex|:
 % \changes{0.1.0}{2022/10/26}{The output is saved to a hash-named file, for better uniqueness of temporary files.}
 % \changes{0.4.0}{2022/11/29}{Now, \TeX output has a log message with the number of the line in the source file, which we render.}
 %    \begin{macrocode}

--- a/docshots.dtx
+++ b/docshots.dtx
@@ -518,6 +518,23 @@ Hello, world!
   \def\docshots@gsdefault{gs}%
   \def\docshots@sep{/}%
 \fi
+%    \end{macrocode}
+% On Unix we render inside the temporary directory. On Windows we cannot, since
+% |cmd.exe| keeps a |cd| in effect after the parentheses close, which would send
+% iexec's exit-code file to the wrong place; instead we stay put and point
+% |pdflatex| at the directory with |-output-directory|:
+%    \begin{macrocode}
+\ifdocshots@windows
+  \def\docshots@render{"\docshots@pdflatex"
+    -interaction=errorstopmode -halt-on-error -shell-escape
+    -output-directory="\docshots@tmpdir\docshots@sep\jobname"
+    "\docshots@tmpdir\docshots@sep\jobname\docshots@sep\hash.tex"}%
+\else
+  \def\docshots@render{cd "\docshots@tmpdir/\jobname" &&
+    "\docshots@pdflatex"
+    -interaction=errorstopmode -halt-on-error -shell-escape
+    \hash.tex}%
+\fi
 \def\docshots@log{}
 \pgfkeys{
   /docshots/.cd,
@@ -625,12 +642,7 @@ Hello, world!
       \iexec[\docshots@log,
         stdout=\docshots@tmpdir\docshots@sep\jobname\docshots@sep\hash.stdout,
         exit=\docshots@tmpdir\docshots@sep\jobname\docshots@sep\hash.ret,
-        quiet,trace]{cd "\docshots@tmpdir\docshots@sep\jobname" &&
-        "\docshots@pdflatex"
-        -interaction=errorstopmode
-        -halt-on-error
-        -shell-escape
-        \hash.tex}%
+        quiet,trace]{\docshots@render}%
       \ifnum\n=1\else%
         \message{docshots: pdflatex run no.\n^^J}%
       \fi%

--- a/docshots.dtx
+++ b/docshots.dtx
@@ -522,13 +522,14 @@ Hello, world!
 % On Unix we render inside the temporary directory. On Windows we cannot, since
 % |cmd.exe| keeps a |cd| in effect after the parentheses close, which would send
 % iexec's exit-code file to the wrong place; instead we stay put and point
-% |pdflatex| at the directory with |-output-directory|:
+% |pdflatex| at the directory with |-output-directory|. The |pdflatex| arguments
+% keep forward slashes, since \TeX{} reads a backslash as an escape character:
 %    \begin{macrocode}
 \ifdocshots@windows
   \def\docshots@render{"\docshots@pdflatex"
     -interaction=errorstopmode -halt-on-error -shell-escape
-    -output-directory="\docshots@tmpdir\docshots@sep\jobname"
-    "\docshots@tmpdir\docshots@sep\jobname\docshots@sep\hash.tex"}%
+    -output-directory="\docshots@tmpdir/\jobname"
+    "\docshots@tmpdir/\jobname/\hash.tex"}%
 \else
   \def\docshots@render{cd "\docshots@tmpdir/\jobname" &&
     "\docshots@pdflatex"

--- a/docshots.dtx
+++ b/docshots.dtx
@@ -669,11 +669,12 @@ Hello, world!
       the PDF '\docshots@tmpdir/\jobname/\hash.crop.pdf'
       already exists^^J}}
     {\ifdefined\docshots@nocrop
-      \iexec[\docshots@log,quiet]{cp
+      \iexec[\docshots@log,quiet]{perl -MFile::Copy -e "copy(shift,shift) or die q(cannot copy)"
         "\docshots@tmpdir/\jobname/\hash.pdf"
         "\docshots@tmpdir/\jobname/\hash.crop.pdf"}%
       \else%
       \iexec[\docshots@log,quiet]{"\docshots@pdfcrop"
+        --gscmd "\docshots@gs"
         --margins 0
         "\docshots@tmpdir/\jobname/\hash.pdf"
         "\docshots@tmpdir/\jobname/\hash.crop.pdf"}%

--- a/docshots.dtx
+++ b/docshots.dtx
@@ -490,8 +490,9 @@ Hello, world!
 % \changes{0.0.5}{2022/10/24}{Package option "log" added, which enables detailed logging via exec. By default, there is no logging at all.}
 % \changes{0.2.0}{2022/10/26}{New package option "nocrop" added to allow disabling of "pdfcrop" execution.}
 % We also detect Windows, in order to pick the right default for Ghostscript,
-% and we prepare an expanding variant of the string-replacement command
-% for later use in \docshotAfter:
+% the right file separator for shell commands (a backslash, since |cmd.exe|
+% rejects forward slashes in redirection targets), and an expanding variant of
+% the string-replacement command for later use in \docshotAfter:
 % \changes{0.5.0}{2026/07/13}{Windows compatibility: file operations go through Perl, and the "gs" default becomes "gswin64c" on Windows.}
 %    \begin{macrocode}
 \RequirePackage{pgfopts}
@@ -512,8 +513,10 @@ Hello, world!
 \ExplSyntaxOff
 \ifdocshots@windows
   \def\docshots@gsdefault{gswin64c}%
+  \edef\docshots@sep{\@backslashchar}%
 \else
   \def\docshots@gsdefault{gs}%
+  \def\docshots@sep{/}%
 \fi
 \def\docshots@log{}
 \pgfkeys{
@@ -620,9 +623,9 @@ Hello, world!
     \message{docshots: rendering at line no. \the\inputlineno^^J}%
     \foreach \n in {1,...,\docshots@runs}{%
       \iexec[\docshots@log,
-        stdout=\docshots@tmpdir/\jobname/\hash.stdout,
-        exit=\docshots@tmpdir/\jobname/\hash.ret,
-        quiet,trace]{cd "\docshots@tmpdir/\jobname" &&
+        stdout=\docshots@tmpdir\docshots@sep\jobname\docshots@sep\hash.stdout,
+        exit=\docshots@tmpdir\docshots@sep\jobname\docshots@sep\hash.ret,
+        quiet,trace]{cd "\docshots@tmpdir\docshots@sep\jobname" &&
         "\docshots@pdflatex"
         -interaction=errorstopmode
         -halt-on-error
@@ -639,7 +642,7 @@ Hello, world!
       \ifdefined\docshots@after%
         \begingroup%
           \docshots@aftercmd{\n}{\hash}{\hash.tex}%
-          \iexec[\docshots@log,quiet]{cd "\docshots@tmpdir/\jobname" &&
+          \iexec[\docshots@log,quiet]{cd "\docshots@tmpdir\docshots@sep\jobname" &&
             \docshots@aftersh}%
         \endgroup%
       \fi}}%

--- a/testfiles/listings.luatex.tlg
+++ b/testfiles/listings.luatex.tlg
@@ -5,7 +5,7 @@ runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
 docshots: rendering at line no. 19
 runsystem((cd "_docshots-lua/listings" && "pdflatex" -interaction=errorstopmode -halt-on-error -shell-escape F63314680C3E56DE0807DB5FB5BD5519.tex) > _docshots-lua/listings/F63314680C3E56DE0807DB5FB5BD5519.stdout 2>&1; /bin/echo -n $?% >_docshots-lua/listings/F63314680C3E56DE0807DB5FB5BD5519.ret)...executed.
-runsystem(("pdfcrop" --margins 0 "_docshots-lua/listings/F63314680C3E56DE0807DB5FB5BD5519.pdf" "_docshots-lua/listings/F63314680C3E56DE0807DB5FB5BD5519.crop.pdf") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
+runsystem(("pdfcrop" --gscmd "gs" --margins 0 "_docshots-lua/listings/F63314680C3E56DE0807DB5FB5BD5519.pdf" "_docshots-lua/listings/F63314680C3E56DE0807DB5FB5BD5519.crop.pdf") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
 docshots: the PDF is ready from line no. 19

--- a/testfiles/listings.luatex.tlg
+++ b/testfiles/listings.luatex.tlg
@@ -1,17 +1,14 @@
 This is a generated file for the l3build validation system.
 Don't change this file in any respect.
-runsystem((cp "_docshots-lua/listings/docshots-temp.tex" "_docshots-lua/listings/F63314680C3E56DE0807DB5FB5BD5519.tex") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
+runsystem((perl -MFile::Copy -e "copy(shift,shift) or die q(cannot copy)" "_docshots-lua/listings/docshots-temp.tex" "_docshots-lua/listings/F63314680C3E56DE0807DB5FB5BD5519.tex") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
-docshots: rendering at line no. 16
+docshots: rendering at line no. 19
 runsystem((cd "_docshots-lua/listings" && "pdflatex" -interaction=errorstopmode -halt-on-error -shell-escape F63314680C3E56DE0807DB5FB5BD5519.tex) > _docshots-lua/listings/F63314680C3E56DE0807DB5FB5BD5519.stdout 2>&1; /bin/echo -n $?% >_docshots-lua/listings/F63314680C3E56DE0807DB5FB5BD5519.ret)...executed.
-runsystem((rm -f "_docshots-lua/listings/after.sh") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
-runsystem(rm iexec.tmp)...executed.
-runsystem(rm iexec.ret)...executed.
 runsystem(("pdfcrop" --margins 0 "_docshots-lua/listings/F63314680C3E56DE0807DB5FB5BD5519.pdf" "_docshots-lua/listings/F63314680C3E56DE0807DB5FB5BD5519.crop.pdf") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
-docshots: the PDF is ready from line no. 16
+docshots: the PDF is ready from line no. 19
 <_docshots-lua/listings/F63314680C3E56DE0807DB5FB5BD5519.crop.pdf, id=4, 159.59625pt x 578.16pt>
 File: _docshots-lua/listings/F63314680C3E56DE0807DB5FB5BD5519.crop.pdf Graphic file (type pdf)
 <use _docshots-lua/listings/F63314680C3E56DE0807DB5FB5BD5519.crop.pdf>

--- a/testfiles/listings.tlg
+++ b/testfiles/listings.tlg
@@ -1,17 +1,14 @@
 This is a generated file for the l3build validation system.
 Don't change this file in any respect.
-runsystem((cp "_docshots/listings/docshots-temp.tex" "_docshots/listings/F63314680C3E56DE0807DB5FB5BD5519.tex") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
+runsystem((perl -MFile::Copy -e "copy(shift,shift) or die q(cannot copy)" "_docshots/listings/docshots-temp.tex" "_docshots/listings/F63314680C3E56DE0807DB5FB5BD5519.tex") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
-docshots: rendering at line no. 16
+docshots: rendering at line no. 19
 runsystem((cd "_docshots/listings" && "pdflatex" -interaction=errorstopmode -halt-on-error -shell-escape F63314680C3E56DE0807DB5FB5BD5519.tex) > _docshots/listings/F63314680C3E56DE0807DB5FB5BD5519.stdout 2>&1; /bin/echo -n $?% >_docshots/listings/F63314680C3E56DE0807DB5FB5BD5519.ret)...executed.
-runsystem((rm -f "_docshots/listings/after.sh") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
-runsystem(rm iexec.tmp)...executed.
-runsystem(rm iexec.ret)...executed.
 runsystem(("pdfcrop" --margins 0 "_docshots/listings/F63314680C3E56DE0807DB5FB5BD5519.pdf" "_docshots/listings/F63314680C3E56DE0807DB5FB5BD5519.crop.pdf") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
-docshots: the PDF is ready from line no. 16
+docshots: the PDF is ready from line no. 19
 <_docshots/listings/F63314680C3E56DE0807DB5FB5BD5519.crop.pdf, id=4, 159.59625pt x 578.16pt>
 File: _docshots/listings/F63314680C3E56DE0807DB5FB5BD5519.crop.pdf Graphic file (type pdf)
 <use _docshots/listings/F63314680C3E56DE0807DB5FB5BD5519.crop.pdf>

--- a/testfiles/listings.tlg
+++ b/testfiles/listings.tlg
@@ -5,7 +5,7 @@ runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
 docshots: rendering at line no. 19
 runsystem((cd "_docshots/listings" && "pdflatex" -interaction=errorstopmode -halt-on-error -shell-escape F63314680C3E56DE0807DB5FB5BD5519.tex) > _docshots/listings/F63314680C3E56DE0807DB5FB5BD5519.stdout 2>&1; /bin/echo -n $?% >_docshots/listings/F63314680C3E56DE0807DB5FB5BD5519.ret)...executed.
-runsystem(("pdfcrop" --margins 0 "_docshots/listings/F63314680C3E56DE0807DB5FB5BD5519.pdf" "_docshots/listings/F63314680C3E56DE0807DB5FB5BD5519.crop.pdf") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
+runsystem(("pdfcrop" --gscmd "gs" --margins 0 "_docshots/listings/F63314680C3E56DE0807DB5FB5BD5519.pdf" "_docshots/listings/F63314680C3E56DE0807DB5FB5BD5519.crop.pdf") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
 docshots: the PDF is ready from line no. 19

--- a/testfiles/listings.xetex.tlg
+++ b/testfiles/listings.xetex.tlg
@@ -5,7 +5,7 @@ runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
 docshots: rendering at line no. 19
 runsystem((cd "_docshots-xe/listings" && "pdflatex" -interaction=errorstopmode -halt-on-error -shell-escape F63314680C3E56DE0807DB5FB5BD5519.tex) > _docshots-xe/listings/F63314680C3E56DE0807DB5FB5BD5519.stdout 2>&1; /bin/echo -n $?% >_docshots-xe/listings/F63314680C3E56DE0807DB5FB5BD5519.ret)...executed.
-runsystem(("pdfcrop" --margins 0 "_docshots-xe/listings/F63314680C3E56DE0807DB5FB5BD5519.pdf" "_docshots-xe/listings/F63314680C3E56DE0807DB5FB5BD5519.crop.pdf") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
+runsystem(("pdfcrop" --gscmd "gs" --margins 0 "_docshots-xe/listings/F63314680C3E56DE0807DB5FB5BD5519.pdf" "_docshots-xe/listings/F63314680C3E56DE0807DB5FB5BD5519.crop.pdf") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
 docshots: the PDF is ready from line no. 19

--- a/testfiles/listings.xetex.tlg
+++ b/testfiles/listings.xetex.tlg
@@ -1,17 +1,14 @@
 This is a generated file for the l3build validation system.
 Don't change this file in any respect.
-runsystem((cp "_docshots-xe/listings/docshots-temp.tex" "_docshots-xe/listings/F63314680C3E56DE0807DB5FB5BD5519.tex") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
+runsystem((perl -MFile::Copy -e "copy(shift,shift) or die q(cannot copy)" "_docshots-xe/listings/docshots-temp.tex" "_docshots-xe/listings/F63314680C3E56DE0807DB5FB5BD5519.tex") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
-docshots: rendering at line no. 16
+docshots: rendering at line no. 19
 runsystem((cd "_docshots-xe/listings" && "pdflatex" -interaction=errorstopmode -halt-on-error -shell-escape F63314680C3E56DE0807DB5FB5BD5519.tex) > _docshots-xe/listings/F63314680C3E56DE0807DB5FB5BD5519.stdout 2>&1; /bin/echo -n $?% >_docshots-xe/listings/F63314680C3E56DE0807DB5FB5BD5519.ret)...executed.
-runsystem((rm -f "_docshots-xe/listings/after.sh") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
-runsystem(rm iexec.tmp)...executed.
-runsystem(rm iexec.ret)...executed.
 runsystem(("pdfcrop" --margins 0 "_docshots-xe/listings/F63314680C3E56DE0807DB5FB5BD5519.pdf" "_docshots-xe/listings/F63314680C3E56DE0807DB5FB5BD5519.crop.pdf") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
-docshots: the PDF is ready from line no. 16
+docshots: the PDF is ready from line no. 19
 File: _docshots-xe/listings/F63314680C3E56DE0807DB5FB5BD5519.crop.pdf Graphic file (type pdf)
 <use _docshots-xe/listings/F63314680C3E56DE0807DB5FB5BD5519.crop.pdf>
 (_docshots-xe/listings/F63314680C3E56DE0807DB5FB5BD5519.tex)

--- a/testfiles/prerequisites.luatex.tlg
+++ b/testfiles/prerequisites.luatex.tlg
@@ -1,39 +1,27 @@
 This is a generated file for the l3build validation system.
 Don't change this file in any respect.
-runsystem((cp main.bib "_docshots-lua/prerequisites") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
+runsystem((perl -MFile::Copy -e "copy(shift,shift) or die q(cannot copy)" "main.bib" "_docshots-lua/prerequisites/main.bib") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
 docshots: File 'main.bib' copied to '_docshots-lua/prerequisites/main.bib'
-runsystem((/bin/echo -n 'biber --quiet $2' > "_docshots-lua/prerequisites/after.sh") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
+docshots: post-processing command 'biber --quiet $2' registered
+runsystem((perl -MFile::Copy -e "copy(shift,shift) or die q(cannot copy)" "_docshots-lua/prerequisites/docshots-temp.tex" "_docshots-lua/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.tex") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
-docshots: File '_docshots-lua/prerequisites/after.sh' created
-runsystem((cp "_docshots-lua/prerequisites/docshots-temp.tex" "_docshots-lua/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.tex") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
-runsystem(rm iexec.tmp)...executed.
-runsystem(rm iexec.ret)...executed.
-docshots: rendering at line no. 20
+docshots: rendering at line no. 23
 runsystem((cd "_docshots-lua/prerequisites" && "pdflatex" -interaction=errorstopmode -halt-on-error -shell-escape C967FB271644444EA7B8FB7FACCD8F04.tex) > _docshots-lua/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.stdout 2>&1; /bin/echo -n $?% >_docshots-lua/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.ret)...executed.
-runsystem((chmod a+x "_docshots-lua/prerequisites/after.sh") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
-runsystem(rm iexec.tmp)...executed.
-runsystem(rm iexec.ret)...executed.
-runsystem((cd "_docshots-lua/prerequisites" && ./after.sh 1 C967FB271644444EA7B8FB7FACCD8F04 C967FB271644444EA7B8FB7FACCD8F04.tex) > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
+runsystem((cd "_docshots-lua/prerequisites" && biber --quiet C967FB271644444EA7B8FB7FACCD8F04) > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
 runsystem((cd "_docshots-lua/prerequisites" && "pdflatex" -interaction=errorstopmode -halt-on-error -shell-escape C967FB271644444EA7B8FB7FACCD8F04.tex) > _docshots-lua/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.stdout 2>&1; /bin/echo -n $?% >_docshots-lua/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.ret)...executed.
 docshots: pdflatex run no.2
-runsystem((chmod a+x "_docshots-lua/prerequisites/after.sh") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
-runsystem(rm iexec.tmp)...executed.
-runsystem(rm iexec.ret)...executed.
-runsystem((cd "_docshots-lua/prerequisites" && ./after.sh 2 C967FB271644444EA7B8FB7FACCD8F04 C967FB271644444EA7B8FB7FACCD8F04.tex) > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
-runsystem(rm iexec.tmp)...executed.
-runsystem(rm iexec.ret)...executed.
-runsystem((rm -f "_docshots-lua/prerequisites/after.sh") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
+runsystem((cd "_docshots-lua/prerequisites" && biber --quiet C967FB271644444EA7B8FB7FACCD8F04) > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
 runsystem(("pdfcrop" --margins 0 "_docshots-lua/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.pdf" "_docshots-lua/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.crop.pdf") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
-docshots: the PDF is ready from line no. 20
+docshots: the PDF is ready from line no. 23
 <_docshots-lua/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.crop.pdf, id=4, 345.29pt x 77.28876pt>
 File: _docshots-lua/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.crop.pdf Graphic file (type pdf)
 <use _docshots-lua/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.crop.pdf>

--- a/testfiles/prerequisites.luatex.tlg
+++ b/testfiles/prerequisites.luatex.tlg
@@ -18,7 +18,7 @@ docshots: pdflatex run no.2
 runsystem((cd "_docshots-lua/prerequisites" && biber --quiet C967FB271644444EA7B8FB7FACCD8F04) > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
-runsystem(("pdfcrop" --margins 0 "_docshots-lua/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.pdf" "_docshots-lua/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.crop.pdf") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
+runsystem(("pdfcrop" --gscmd "gs" --margins 0 "_docshots-lua/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.pdf" "_docshots-lua/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.crop.pdf") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
 docshots: the PDF is ready from line no. 23

--- a/testfiles/prerequisites.tlg
+++ b/testfiles/prerequisites.tlg
@@ -1,39 +1,27 @@
 This is a generated file for the l3build validation system.
 Don't change this file in any respect.
-runsystem((cp main.bib "_docshots/prerequisites") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
+runsystem((perl -MFile::Copy -e "copy(shift,shift) or die q(cannot copy)" "main.bib" "_docshots/prerequisites/main.bib") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
 docshots: File 'main.bib' copied to '_docshots/prerequisites/main.bib'
-runsystem((/bin/echo -n 'biber --quiet $2' > "_docshots/prerequisites/after.sh") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
+docshots: post-processing command 'biber --quiet $2' registered
+runsystem((perl -MFile::Copy -e "copy(shift,shift) or die q(cannot copy)" "_docshots/prerequisites/docshots-temp.tex" "_docshots/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.tex") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
-docshots: File '_docshots/prerequisites/after.sh' created
-runsystem((cp "_docshots/prerequisites/docshots-temp.tex" "_docshots/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.tex") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
-runsystem(rm iexec.tmp)...executed.
-runsystem(rm iexec.ret)...executed.
-docshots: rendering at line no. 20
+docshots: rendering at line no. 23
 runsystem((cd "_docshots/prerequisites" && "pdflatex" -interaction=errorstopmode -halt-on-error -shell-escape C967FB271644444EA7B8FB7FACCD8F04.tex) > _docshots/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.stdout 2>&1; /bin/echo -n $?% >_docshots/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.ret)...executed.
-runsystem((chmod a+x "_docshots/prerequisites/after.sh") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
-runsystem(rm iexec.tmp)...executed.
-runsystem(rm iexec.ret)...executed.
-runsystem((cd "_docshots/prerequisites" && ./after.sh 1 C967FB271644444EA7B8FB7FACCD8F04 C967FB271644444EA7B8FB7FACCD8F04.tex) > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
+runsystem((cd "_docshots/prerequisites" && biber --quiet C967FB271644444EA7B8FB7FACCD8F04) > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
 runsystem((cd "_docshots/prerequisites" && "pdflatex" -interaction=errorstopmode -halt-on-error -shell-escape C967FB271644444EA7B8FB7FACCD8F04.tex) > _docshots/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.stdout 2>&1; /bin/echo -n $?% >_docshots/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.ret)...executed.
 docshots: pdflatex run no.2
-runsystem((chmod a+x "_docshots/prerequisites/after.sh") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
-runsystem(rm iexec.tmp)...executed.
-runsystem(rm iexec.ret)...executed.
-runsystem((cd "_docshots/prerequisites" && ./after.sh 2 C967FB271644444EA7B8FB7FACCD8F04 C967FB271644444EA7B8FB7FACCD8F04.tex) > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
-runsystem(rm iexec.tmp)...executed.
-runsystem(rm iexec.ret)...executed.
-runsystem((rm -f "_docshots/prerequisites/after.sh") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
+runsystem((cd "_docshots/prerequisites" && biber --quiet C967FB271644444EA7B8FB7FACCD8F04) > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
 runsystem(("pdfcrop" --margins 0 "_docshots/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.pdf" "_docshots/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.crop.pdf") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
-docshots: the PDF is ready from line no. 20
+docshots: the PDF is ready from line no. 23
 <_docshots/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.crop.pdf, id=4, 345.29pt x 77.28876pt>
 File: _docshots/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.crop.pdf Graphic file (type pdf)
 <use _docshots/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.crop.pdf>

--- a/testfiles/prerequisites.tlg
+++ b/testfiles/prerequisites.tlg
@@ -18,7 +18,7 @@ docshots: pdflatex run no.2
 runsystem((cd "_docshots/prerequisites" && biber --quiet C967FB271644444EA7B8FB7FACCD8F04) > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
-runsystem(("pdfcrop" --margins 0 "_docshots/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.pdf" "_docshots/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.crop.pdf") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
+runsystem(("pdfcrop" --gscmd "gs" --margins 0 "_docshots/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.pdf" "_docshots/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.crop.pdf") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
 docshots: the PDF is ready from line no. 23

--- a/testfiles/prerequisites.xetex.tlg
+++ b/testfiles/prerequisites.xetex.tlg
@@ -1,38 +1,26 @@
 This is a generated file for the l3build validation system.
 Don't change this file in any respect.
-runsystem((cp main.bib "_docshots-xe/prerequisites") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
+runsystem((perl -MFile::Copy -e "copy(shift,shift) or die q(cannot copy)" "main.bib" "_docshots-xe/prerequisites/main.bib") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
 docshots: File 'main.bib' copied to '_docshots-xe/prerequisites/main.bib'
-runsystem((/bin/echo -n 'biber --quiet $2' > "_docshots-xe/prerequisites/after.sh") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
+docshots: post-processing command 'biber --quiet $2' registered
+runsystem((perl -MFile::Copy -e "copy(shift,shift) or die q(cannot copy)" "_docshots-xe/prerequisites/docshots-temp.tex" "_docshots-xe/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.tex") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
-docshots: File '_docshots-xe/prerequisites/after.sh' created
-runsystem((cp "_docshots-xe/prerequisites/docshots-temp.tex" "_docshots-xe/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.tex") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
-runsystem(rm iexec.tmp)...executed.
-runsystem(rm iexec.ret)...executed.
-docshots: rendering at line no. 20
+docshots: rendering at line no. 23
 runsystem((cd "_docshots-xe/prerequisites" && "pdflatex" -interaction=errorstopmode -halt-on-error -shell-escape C967FB271644444EA7B8FB7FACCD8F04.tex) > _docshots-xe/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.stdout 2>&1; /bin/echo -n $?% >_docshots-xe/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.ret)...executed.
-runsystem((chmod a+x "_docshots-xe/prerequisites/after.sh") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
-runsystem(rm iexec.tmp)...executed.
-runsystem(rm iexec.ret)...executed.
-runsystem((cd "_docshots-xe/prerequisites" && ./after.sh 1 C967FB271644444EA7B8FB7FACCD8F04 C967FB271644444EA7B8FB7FACCD8F04.tex) > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
+runsystem((cd "_docshots-xe/prerequisites" && biber --quiet C967FB271644444EA7B8FB7FACCD8F04) > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
 runsystem((cd "_docshots-xe/prerequisites" && "pdflatex" -interaction=errorstopmode -halt-on-error -shell-escape C967FB271644444EA7B8FB7FACCD8F04.tex) > _docshots-xe/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.stdout 2>&1; /bin/echo -n $?% >_docshots-xe/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.ret)...executed.
 docshots: pdflatex run no.2
-runsystem((chmod a+x "_docshots-xe/prerequisites/after.sh") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
-runsystem(rm iexec.tmp)...executed.
-runsystem(rm iexec.ret)...executed.
-runsystem((cd "_docshots-xe/prerequisites" && ./after.sh 2 C967FB271644444EA7B8FB7FACCD8F04 C967FB271644444EA7B8FB7FACCD8F04.tex) > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
-runsystem(rm iexec.tmp)...executed.
-runsystem(rm iexec.ret)...executed.
-runsystem((rm -f "_docshots-xe/prerequisites/after.sh") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
+runsystem((cd "_docshots-xe/prerequisites" && biber --quiet C967FB271644444EA7B8FB7FACCD8F04) > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
 runsystem(("pdfcrop" --margins 0 "_docshots-xe/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.pdf" "_docshots-xe/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.crop.pdf") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
-docshots: the PDF is ready from line no. 20
+docshots: the PDF is ready from line no. 23
 File: _docshots-xe/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.crop.pdf Graphic file (type pdf)
 <use _docshots-xe/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.crop.pdf>

--- a/testfiles/prerequisites.xetex.tlg
+++ b/testfiles/prerequisites.xetex.tlg
@@ -18,7 +18,7 @@ docshots: pdflatex run no.2
 runsystem((cd "_docshots-xe/prerequisites" && biber --quiet C967FB271644444EA7B8FB7FACCD8F04) > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
-runsystem(("pdfcrop" --margins 0 "_docshots-xe/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.pdf" "_docshots-xe/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.crop.pdf") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
+runsystem(("pdfcrop" --gscmd "gs" --margins 0 "_docshots-xe/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.pdf" "_docshots-xe/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.crop.pdf") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
 docshots: the PDF is ready from line no. 23

--- a/testfiles/simple.luatex.tlg
+++ b/testfiles/simple.luatex.tlg
@@ -1,17 +1,14 @@
 This is a generated file for the l3build validation system.
 Don't change this file in any respect.
-runsystem((cp "_docshots-lua/simple/docshots-temp.tex" "_docshots-lua/simple/F63314680C3E56DE0807DB5FB5BD5519.tex") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
+runsystem((perl -MFile::Copy -e "copy(shift,shift) or die q(cannot copy)" "_docshots-lua/simple/docshots-temp.tex" "_docshots-lua/simple/F63314680C3E56DE0807DB5FB5BD5519.tex") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
-docshots: rendering at line no. 14
+docshots: rendering at line no. 17
 runsystem((cd "_docshots-lua/simple" && "pdflatex" -interaction=errorstopmode -halt-on-error -shell-escape F63314680C3E56DE0807DB5FB5BD5519.tex) > _docshots-lua/simple/F63314680C3E56DE0807DB5FB5BD5519.stdout 2>&1; /bin/echo -n $?% >_docshots-lua/simple/F63314680C3E56DE0807DB5FB5BD5519.ret)...executed.
-runsystem((rm -f "_docshots-lua/simple/after.sh") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
-runsystem(rm iexec.tmp)...executed.
-runsystem(rm iexec.ret)...executed.
 runsystem(("pdfcrop" --margins 0 "_docshots-lua/simple/F63314680C3E56DE0807DB5FB5BD5519.pdf" "_docshots-lua/simple/F63314680C3E56DE0807DB5FB5BD5519.crop.pdf") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
-docshots: the PDF is ready from line no. 14
+docshots: the PDF is ready from line no. 17
 <_docshots-lua/simple/F63314680C3E56DE0807DB5FB5BD5519.crop.pdf, id=4, 159.59625pt x 578.16pt>
 File: _docshots-lua/simple/F63314680C3E56DE0807DB5FB5BD5519.crop.pdf Graphic file (type pdf)
 <use _docshots-lua/simple/F63314680C3E56DE0807DB5FB5BD5519.crop.pdf>

--- a/testfiles/simple.luatex.tlg
+++ b/testfiles/simple.luatex.tlg
@@ -5,7 +5,7 @@ runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
 docshots: rendering at line no. 17
 runsystem((cd "_docshots-lua/simple" && "pdflatex" -interaction=errorstopmode -halt-on-error -shell-escape F63314680C3E56DE0807DB5FB5BD5519.tex) > _docshots-lua/simple/F63314680C3E56DE0807DB5FB5BD5519.stdout 2>&1; /bin/echo -n $?% >_docshots-lua/simple/F63314680C3E56DE0807DB5FB5BD5519.ret)...executed.
-runsystem(("pdfcrop" --margins 0 "_docshots-lua/simple/F63314680C3E56DE0807DB5FB5BD5519.pdf" "_docshots-lua/simple/F63314680C3E56DE0807DB5FB5BD5519.crop.pdf") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
+runsystem(("pdfcrop" --gscmd "gs" --margins 0 "_docshots-lua/simple/F63314680C3E56DE0807DB5FB5BD5519.pdf" "_docshots-lua/simple/F63314680C3E56DE0807DB5FB5BD5519.crop.pdf") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
 docshots: the PDF is ready from line no. 17

--- a/testfiles/simple.tlg
+++ b/testfiles/simple.tlg
@@ -1,17 +1,14 @@
 This is a generated file for the l3build validation system.
 Don't change this file in any respect.
-runsystem((cp "_docshots/simple/docshots-temp.tex" "_docshots/simple/F63314680C3E56DE0807DB5FB5BD5519.tex") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
+runsystem((perl -MFile::Copy -e "copy(shift,shift) or die q(cannot copy)" "_docshots/simple/docshots-temp.tex" "_docshots/simple/F63314680C3E56DE0807DB5FB5BD5519.tex") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
-docshots: rendering at line no. 14
+docshots: rendering at line no. 17
 runsystem((cd "_docshots/simple" && "pdflatex" -interaction=errorstopmode -halt-on-error -shell-escape F63314680C3E56DE0807DB5FB5BD5519.tex) > _docshots/simple/F63314680C3E56DE0807DB5FB5BD5519.stdout 2>&1; /bin/echo -n $?% >_docshots/simple/F63314680C3E56DE0807DB5FB5BD5519.ret)...executed.
-runsystem((rm -f "_docshots/simple/after.sh") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
-runsystem(rm iexec.tmp)...executed.
-runsystem(rm iexec.ret)...executed.
 runsystem(("pdfcrop" --margins 0 "_docshots/simple/F63314680C3E56DE0807DB5FB5BD5519.pdf" "_docshots/simple/F63314680C3E56DE0807DB5FB5BD5519.crop.pdf") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
-docshots: the PDF is ready from line no. 14
+docshots: the PDF is ready from line no. 17
 <_docshots/simple/F63314680C3E56DE0807DB5FB5BD5519.crop.pdf, id=4, 159.59625pt x 578.16pt>
 File: _docshots/simple/F63314680C3E56DE0807DB5FB5BD5519.crop.pdf Graphic file (type pdf)
 <use _docshots/simple/F63314680C3E56DE0807DB5FB5BD5519.crop.pdf>

--- a/testfiles/simple.tlg
+++ b/testfiles/simple.tlg
@@ -5,7 +5,7 @@ runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
 docshots: rendering at line no. 17
 runsystem((cd "_docshots/simple" && "pdflatex" -interaction=errorstopmode -halt-on-error -shell-escape F63314680C3E56DE0807DB5FB5BD5519.tex) > _docshots/simple/F63314680C3E56DE0807DB5FB5BD5519.stdout 2>&1; /bin/echo -n $?% >_docshots/simple/F63314680C3E56DE0807DB5FB5BD5519.ret)...executed.
-runsystem(("pdfcrop" --margins 0 "_docshots/simple/F63314680C3E56DE0807DB5FB5BD5519.pdf" "_docshots/simple/F63314680C3E56DE0807DB5FB5BD5519.crop.pdf") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
+runsystem(("pdfcrop" --gscmd "gs" --margins 0 "_docshots/simple/F63314680C3E56DE0807DB5FB5BD5519.pdf" "_docshots/simple/F63314680C3E56DE0807DB5FB5BD5519.crop.pdf") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
 docshots: the PDF is ready from line no. 17

--- a/testfiles/simple.xetex.tlg
+++ b/testfiles/simple.xetex.tlg
@@ -5,7 +5,7 @@ runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
 docshots: rendering at line no. 17
 runsystem((cd "_docshots-xe/simple" && "pdflatex" -interaction=errorstopmode -halt-on-error -shell-escape F63314680C3E56DE0807DB5FB5BD5519.tex) > _docshots-xe/simple/F63314680C3E56DE0807DB5FB5BD5519.stdout 2>&1; /bin/echo -n $?% >_docshots-xe/simple/F63314680C3E56DE0807DB5FB5BD5519.ret)...executed.
-runsystem(("pdfcrop" --margins 0 "_docshots-xe/simple/F63314680C3E56DE0807DB5FB5BD5519.pdf" "_docshots-xe/simple/F63314680C3E56DE0807DB5FB5BD5519.crop.pdf") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
+runsystem(("pdfcrop" --gscmd "gs" --margins 0 "_docshots-xe/simple/F63314680C3E56DE0807DB5FB5BD5519.pdf" "_docshots-xe/simple/F63314680C3E56DE0807DB5FB5BD5519.crop.pdf") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
 docshots: the PDF is ready from line no. 17

--- a/testfiles/simple.xetex.tlg
+++ b/testfiles/simple.xetex.tlg
@@ -1,16 +1,13 @@
 This is a generated file for the l3build validation system.
 Don't change this file in any respect.
-runsystem((cp "_docshots-xe/simple/docshots-temp.tex" "_docshots-xe/simple/F63314680C3E56DE0807DB5FB5BD5519.tex") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
+runsystem((perl -MFile::Copy -e "copy(shift,shift) or die q(cannot copy)" "_docshots-xe/simple/docshots-temp.tex" "_docshots-xe/simple/F63314680C3E56DE0807DB5FB5BD5519.tex") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
-docshots: rendering at line no. 14
+docshots: rendering at line no. 17
 runsystem((cd "_docshots-xe/simple" && "pdflatex" -interaction=errorstopmode -halt-on-error -shell-escape F63314680C3E56DE0807DB5FB5BD5519.tex) > _docshots-xe/simple/F63314680C3E56DE0807DB5FB5BD5519.stdout 2>&1; /bin/echo -n $?% >_docshots-xe/simple/F63314680C3E56DE0807DB5FB5BD5519.ret)...executed.
-runsystem((rm -f "_docshots-xe/simple/after.sh") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
-runsystem(rm iexec.tmp)...executed.
-runsystem(rm iexec.ret)...executed.
 runsystem(("pdfcrop" --margins 0 "_docshots-xe/simple/F63314680C3E56DE0807DB5FB5BD5519.pdf" "_docshots-xe/simple/F63314680C3E56DE0807DB5FB5BD5519.crop.pdf") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
-docshots: the PDF is ready from line no. 14
+docshots: the PDF is ready from line no. 17
 File: _docshots-xe/simple/F63314680C3E56DE0807DB5FB5BD5519.crop.pdf Graphic file (type pdf)
 <use _docshots-xe/simple/F63314680C3E56DE0807DB5FB5BD5519.crop.pdf>


### PR DESCRIPTION
This teaches docshots to run on Windows. The file operations that used to
call `mkdir -p`, `cp`, and `rm -f` now go through Perl, which is already a
prerequisite and happily takes forward-slash paths on any platform. The
`\docshotAfter` command no longer writes a shell script and `chmod`s it;
instead the command string is kept in TeX, its `$1`/`$2`/`$3` placeholders
are substituted there, and it is executed directly. Ghostscript now
defaults to `gswin64c` on Windows, and its version probe is treated as
non-fatal so a missing or differently-named binary does not abort a build.

Until now the package flatly stated it did not run on Windows, even though
the rendering logic was platform-agnostic and iexec already handles the
Windows shell. The only thing standing in the way was this handful of
Unix-only commands.

CI now runs on Windows too. Because iexec writes OS-specific shell wrappers
(`del`/`NUL` vs `rm`/`/bin/echo`) into the logs, the regression `.tlg`
comparison cannot match across platforms, so the Windows job builds the
documentation instead — that drives the whole render pipeline end to end and
fails loudly if any command is still Windows-incompatible. The regenerated
`.tlg` files also pick up a line-number shift that an earlier copyright-header
change had left stale.

Closes #62