### PR TITLE
Add snippet option to place or hide the verbatim source

### DIFF
--- a/docshots.dtx
+++ b/docshots.dtx
@@ -263,6 +263,21 @@ Hello, world!
 %</verb>
 %\fi
 
+% \DescribeMacro{snippet}
+% By default, the verbatim \TeX{} source is placed to the right of the snapshot.
+% The |snippet| option accepts one of three values---|left|, |right|, or
+% |none|---to place the source on either side of the snapshot or to suppress it
+% entirely, leaving the snapshot alone:
+%\iffalse
+%<*verb>
+%\fi
+\begin{verbatim}
+\usepackage[snippet=left]{docshots}
+\end{verbatim}
+%\iffalse
+%</verb>
+%\fi
+
 % \DescribeMacro{dtx}
 % Whenever this package is employed within |.dtx| documentation, the |dtx| package option must be added. Under
 % this option, all leading comment symbols (the |%| characters) are removed from the start of each line:
@@ -382,6 +397,25 @@ Hello, world!
 
 % The options are cleared upon the first rendering of a docshot.
 
+% \DescribeMacro{\docshotSnippet}
+% \changes{0.6.0}{2026/07/16}{The command is added to override the "snippet" placement of a single docshot.}
+% The package-wide |snippet| option may be overridden for a single docshot by
+% means of the |\docshotSnippet| command, which likewise accepts |left|,
+% |right|, or |none| and applies solely to the |docshot| that immediately
+% follows it:
+%\iffalse
+%<*verb>
+%\fi
+\begin{verbatim}
+\docshotSnippet{none}
+\begin{docshot}
+...
+\end{docshot}
+\end{verbatim}
+%\iffalse
+%</verb>
+%\fi
+
 % \section{Prerequisites}
 
 % \DescribeMacro{\docshotPrerequisite}
@@ -495,6 +529,7 @@ Hello, world!
 % \changes{0.0.4}{2022/10/18}{Package options "lstinputlisting" and "inputminted" introduced to enable printing of verbatim text via either the listings or the minted package.}
 % \changes{0.0.5}{2022/10/24}{Package option "log" added, which enables detailed logging via exec. By default, there is no logging at all.}
 % \changes{0.2.0}{2022/10/26}{New package option "nocrop" added to allow disabling of "pdfcrop" execution.}
+% \changes{0.6.0}{2026/07/16}{Package option "snippet" added, with values "left", "right", and "none", to place the verbatim source on either side of the snapshot or to omit it entirely.}
 % We also detect Windows, in order to pick the right default for Ghostscript,
 % the right file separator for shell commands (a backslash, since |cmd.exe|
 % rejects forward slashes in redirection targets), and an expanding variant of
@@ -570,9 +605,18 @@ Hello, world!
   left/.default=.3\linewidth,
   right/.store in=\docshots@right,
   right/.default=.55\linewidth,
-  tmpdir,pdflatex,gs,pdfcrop,margin,hspace,left,right,runs
+  snippet/.store in=\docshots@snippet,
+  snippet/.default=right,
+  tmpdir,pdflatex,gs,pdfcrop,margin,hspace,left,right,snippet,runs
 }
 \ProcessPgfOptions{/docshots}
+%    \end{macrocode}
+% We remember the three admissible values of the |snippet| option, so that a
+% docshot may later compare its own placement against them:
+%    \begin{macrocode}
+\def\docshots@snippetleft{left}
+\def\docshots@snippetright{right}
+\def\docshots@snippetnone{none}
 %    \end{macrocode}
 
 % Then, we print the version of |pdflatex| to the \TeX{} log:
@@ -691,17 +735,22 @@ Hello, world!
       \fi}%
   \message{docshots: the PDF is ready from line no. \the\inputlineno^^J}%
 %    \end{macrocode}
-% Finally, we render the two-column content:
+% Finally, we render the content. When no per-docshot placement was requested
+% via \docshotSnippet, we inherit the package-wide |snippet| setting. The
+% snapshot is a framed image, and the source is a top-aligned minipage; we
+% keep each in a macro of its own, so that either may precede the other:
 %    \begin{macrocode}
   \begingroup%
   \par%
-  \tikz[baseline=(a.north)]
+  \ifdefined\docshots@thissnippet\else%
+    \let\docshots@thissnippet\docshots@snippet%
+  \fi%
+  \def\docshots@image{\tikz[baseline=(a.north)]
     \node (a) [draw=gray,inner sep=\docshots@margin,
       line width=.2pt]
     {\includegraphics[width=\docshots@left]
-      {\docshots@tmpdir/\jobname/\hash.crop.pdf}};%
-  \hspace{\docshots@hspace}%
-  \begin{minipage}[t]{\docshots@right}%
+      {\docshots@tmpdir/\jobname/\hash.crop.pdf}};}%
+  \def\docshots@code{\begin{minipage}[t]{\docshots@right}%
     \vspace{0pt}%
     \ifdefined\docshots@lstinputlisting%
       \ifdefined\docshots@opts%
@@ -730,9 +779,24 @@ Hello, world!
       \VerbatimInput{\docshots@tmpdir/\jobname/\hash.tex}%
     \fi\fi%
     \vspace{0pt}%
-  \end{minipage}%
+  \end{minipage}}%
+%    \end{macrocode}
+% According to the |snippet| setting, the source stands to the left of the
+% snapshot, to its right, or is omitted altogether:
+%    \begin{macrocode}
+  \ifx\docshots@thissnippet\docshots@snippetnone%
+    \docshots@image%
+  \else\ifx\docshots@thissnippet\docshots@snippetleft%
+    \docshots@code\hspace{\docshots@hspace}\docshots@image%
+  \else\ifx\docshots@thissnippet\docshots@snippetright%
+    \docshots@image\hspace{\docshots@hspace}\docshots@code%
+  \else%
+    \PackageError{docshots}{Unknown snippet
+      '\docshots@thissnippet', use left, right, or none}{}%
+  \fi\fi\fi%
   \par%
   \endgroup%
+  \global\let\docshots@thissnippet\@undefined%
   \docshotOptions{}%
 }
 \makeatother
@@ -763,6 +827,19 @@ Hello, world!
 \newcommand\docshotAfter[1]{
   \xdef\docshots@after{\detokenize{#1}}%
   \message{docshots: post-processing command '\docshots@after' registered^^J}%
+}
+\makeatother
+%    \end{macrocode}
+% \end{macro}
+
+% \begin{macro}{\docshotSnippet}
+% Then, we define |\docshotSnippet| command, which overrides the |snippet|
+% placement for the single docshot that follows it:
+% \changes{0.6.0}{2026/07/16}{New command introduced to override the "snippet" placement of a single docshot.}
+%    \begin{macrocode}
+\makeatletter
+\newcommand\docshotSnippet[1]{%
+  \gdef\docshots@thissnippet{#1}%
 }
 \makeatother
 %    \end{macrocode}

--- a/testfiles/snippet.luatex.tlg
+++ b/testfiles/snippet.luatex.tlg
@@ -1,0 +1,46 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+runsystem((perl -MFile::Copy -e "copy(shift,shift) or die q(cannot copy)" "_docshots-lua/snippet/docshots-temp.tex" "_docshots-lua/snippet/6E11CC1997D30A6656B18B0C776612DD.tex") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
+runsystem(rm iexec.tmp)...executed.
+runsystem(rm iexec.ret)...executed.
+docshots: rendering at line no. 16
+runsystem((cd "_docshots-lua/snippet" && "pdflatex" -interaction=errorstopmode -halt-on-error -shell-escape 6E11CC1997D30A6656B18B0C776612DD.tex) > _docshots-lua/snippet/6E11CC1997D30A6656B18B0C776612DD.stdout 2>&1; /bin/echo -n $?% >_docshots-lua/snippet/6E11CC1997D30A6656B18B0C776612DD.ret)...executed.
+runsystem(("pdfcrop" --gscmd "gs" --margins 0 "_docshots-lua/snippet/6E11CC1997D30A6656B18B0C776612DD.pdf" "_docshots-lua/snippet/6E11CC1997D30A6656B18B0C776612DD.crop.pdf") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
+runsystem(rm iexec.tmp)...executed.
+runsystem(rm iexec.ret)...executed.
+docshots: the PDF is ready from line no. 16
+<_docshots-lua/snippet/6E11CC1997D30A6656B18B0C776612DD.crop.pdf, id=4, 159.59625pt x 578.16pt>
+File: _docshots-lua/snippet/6E11CC1997D30A6656B18B0C776612DD.crop.pdf Graphic file (type pdf)
+<use _docshots-lua/snippet/6E11CC1997D30A6656B18B0C776612DD.crop.pdf>
+Package luatex.def Info: _docshots-lua/snippet/6E11CC1997D30A6656B18B0C776612DD.crop.pdf  used on input line ....
+(luatex.def)             Requested size: 103.50105pt x 374.94382pt.
+runsystem((perl -MFile::Copy -e "copy(shift,shift) or die q(cannot copy)" "_docshots-lua/snippet/docshots-temp.tex" "_docshots-lua/snippet/6BC193BC30DAEA956E52AECAFFE6CDA2.tex") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
+runsystem(rm iexec.tmp)...executed.
+runsystem(rm iexec.ret)...executed.
+docshots: rendering at line no. 24
+runsystem((cd "_docshots-lua/snippet" && "pdflatex" -interaction=errorstopmode -halt-on-error -shell-escape 6BC193BC30DAEA956E52AECAFFE6CDA2.tex) > _docshots-lua/snippet/6BC193BC30DAEA956E52AECAFFE6CDA2.stdout 2>&1; /bin/echo -n $?% >_docshots-lua/snippet/6BC193BC30DAEA956E52AECAFFE6CDA2.ret)...executed.
+runsystem(("pdfcrop" --gscmd "gs" --margins 0 "_docshots-lua/snippet/6BC193BC30DAEA956E52AECAFFE6CDA2.pdf" "_docshots-lua/snippet/6BC193BC30DAEA956E52AECAFFE6CDA2.crop.pdf") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
+runsystem(rm iexec.tmp)...executed.
+runsystem(rm iexec.ret)...executed.
+docshots: the PDF is ready from line no. 24
+<_docshots-lua/snippet/6BC193BC30DAEA956E52AECAFFE6CDA2.crop.pdf, id=5, 159.59625pt x 578.16pt>
+File: _docshots-lua/snippet/6BC193BC30DAEA956E52AECAFFE6CDA2.crop.pdf Graphic file (type pdf)
+<use _docshots-lua/snippet/6BC193BC30DAEA956E52AECAFFE6CDA2.crop.pdf>
+Package luatex.def Info: _docshots-lua/snippet/6BC193BC30DAEA956E52AECAFFE6CDA2.crop.pdf  used on input line ....
+(luatex.def)             Requested size: 103.50105pt x 374.94382pt.
+runsystem((perl -MFile::Copy -e "copy(shift,shift) or die q(cannot copy)" "_docshots-lua/snippet/docshots-temp.tex" "_docshots-lua/snippet/C0BDB1F9A833386F0C21ACFD59F1B7AE.tex") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
+runsystem(rm iexec.tmp)...executed.
+runsystem(rm iexec.ret)...executed.
+docshots: rendering at line no. 32
+runsystem((cd "_docshots-lua/snippet" && "pdflatex" -interaction=errorstopmode -halt-on-error -shell-escape C0BDB1F9A833386F0C21ACFD59F1B7AE.tex) > _docshots-lua/snippet/C0BDB1F9A833386F0C21ACFD59F1B7AE.stdout 2>&1; /bin/echo -n $?% >_docshots-lua/snippet/C0BDB1F9A833386F0C21ACFD59F1B7AE.ret)...executed.
+runsystem(("pdfcrop" --gscmd "gs" --margins 0 "_docshots-lua/snippet/C0BDB1F9A833386F0C21ACFD59F1B7AE.pdf" "_docshots-lua/snippet/C0BDB1F9A833386F0C21ACFD59F1B7AE.crop.pdf") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
+runsystem(rm iexec.tmp)...executed.
+runsystem(rm iexec.ret)...executed.
+docshots: the PDF is ready from line no. 32
+<_docshots-lua/snippet/C0BDB1F9A833386F0C21ACFD59F1B7AE.crop.pdf, id=6, 159.59625pt x 577.15625pt>
+File: _docshots-lua/snippet/C0BDB1F9A833386F0C21ACFD59F1B7AE.crop.pdf Graphic file (type pdf)
+<use _docshots-lua/snippet/C0BDB1F9A833386F0C21ACFD59F1B7AE.crop.pdf>
+Package luatex.def Info: _docshots-lua/snippet/C0BDB1F9A833386F0C21ACFD59F1B7AE.crop.pdf  used on input line ....
+(luatex.def)             Requested size: 103.50105pt x 374.29286pt.
+[1
+<./_docshots-lua/snippet/6E11CC1997D30A6656B18B0C776612DD.crop.pdf>]

--- a/testfiles/snippet.lvt
+++ b/testfiles/snippet.lvt
@@ -1,0 +1,34 @@
+% SPDX-FileCopyrightText: Copyright (c) 2021-2026 Yegor Bugayenko
+% SPDX-License-Identifier: MIT
+
+\input{regression-test.tex}
+\documentclass{article}
+\usepackage[snippet=left]{docshots}
+\begin{document}
+
+\START
+
+\begin{docshot}
+\documentclass{article}
+\begin{document}
+  Left snippet.
+\end{document}
+\end{docshot}
+
+\docshotSnippet{right}
+\begin{docshot}
+\documentclass{article}
+\begin{document}
+  Right snippet.
+\end{document}
+\end{docshot}
+
+\docshotSnippet{none}
+\begin{docshot}
+\documentclass{article}
+\begin{document}
+  No snippet.
+\end{document}
+\end{docshot}
+
+\END

--- a/testfiles/snippet.tlg
+++ b/testfiles/snippet.tlg
@@ -1,0 +1,46 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+runsystem((perl -MFile::Copy -e "copy(shift,shift) or die q(cannot copy)" "_docshots/snippet/docshots-temp.tex" "_docshots/snippet/6E11CC1997D30A6656B18B0C776612DD.tex") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
+runsystem(rm iexec.tmp)...executed.
+runsystem(rm iexec.ret)...executed.
+docshots: rendering at line no. 16
+runsystem((cd "_docshots/snippet" && "pdflatex" -interaction=errorstopmode -halt-on-error -shell-escape 6E11CC1997D30A6656B18B0C776612DD.tex) > _docshots/snippet/6E11CC1997D30A6656B18B0C776612DD.stdout 2>&1; /bin/echo -n $?% >_docshots/snippet/6E11CC1997D30A6656B18B0C776612DD.ret)...executed.
+runsystem(("pdfcrop" --gscmd "gs" --margins 0 "_docshots/snippet/6E11CC1997D30A6656B18B0C776612DD.pdf" "_docshots/snippet/6E11CC1997D30A6656B18B0C776612DD.crop.pdf") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
+runsystem(rm iexec.tmp)...executed.
+runsystem(rm iexec.ret)...executed.
+docshots: the PDF is ready from line no. 16
+<_docshots/snippet/6E11CC1997D30A6656B18B0C776612DD.crop.pdf, id=4, 159.59625pt x 578.16pt>
+File: _docshots/snippet/6E11CC1997D30A6656B18B0C776612DD.crop.pdf Graphic file (type pdf)
+<use _docshots/snippet/6E11CC1997D30A6656B18B0C776612DD.crop.pdf>
+Package pdftex.def Info: _docshots/snippet/6E11CC1997D30A6656B18B0C776612DD.crop.pdf  used on input line ....
+(pdftex.def)             Requested size: 103.50105pt x 374.94382pt.
+runsystem((perl -MFile::Copy -e "copy(shift,shift) or die q(cannot copy)" "_docshots/snippet/docshots-temp.tex" "_docshots/snippet/6BC193BC30DAEA956E52AECAFFE6CDA2.tex") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
+runsystem(rm iexec.tmp)...executed.
+runsystem(rm iexec.ret)...executed.
+docshots: rendering at line no. 24
+runsystem((cd "_docshots/snippet" && "pdflatex" -interaction=errorstopmode -halt-on-error -shell-escape 6BC193BC30DAEA956E52AECAFFE6CDA2.tex) > _docshots/snippet/6BC193BC30DAEA956E52AECAFFE6CDA2.stdout 2>&1; /bin/echo -n $?% >_docshots/snippet/6BC193BC30DAEA956E52AECAFFE6CDA2.ret)...executed.
+runsystem(("pdfcrop" --gscmd "gs" --margins 0 "_docshots/snippet/6BC193BC30DAEA956E52AECAFFE6CDA2.pdf" "_docshots/snippet/6BC193BC30DAEA956E52AECAFFE6CDA2.crop.pdf") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
+runsystem(rm iexec.tmp)...executed.
+runsystem(rm iexec.ret)...executed.
+docshots: the PDF is ready from line no. 24
+<_docshots/snippet/6BC193BC30DAEA956E52AECAFFE6CDA2.crop.pdf, id=5, 159.59625pt x 578.16pt>
+File: _docshots/snippet/6BC193BC30DAEA956E52AECAFFE6CDA2.crop.pdf Graphic file (type pdf)
+<use _docshots/snippet/6BC193BC30DAEA956E52AECAFFE6CDA2.crop.pdf>
+Package pdftex.def Info: _docshots/snippet/6BC193BC30DAEA956E52AECAFFE6CDA2.crop.pdf  used on input line ....
+(pdftex.def)             Requested size: 103.50105pt x 374.94382pt.
+runsystem((perl -MFile::Copy -e "copy(shift,shift) or die q(cannot copy)" "_docshots/snippet/docshots-temp.tex" "_docshots/snippet/C0BDB1F9A833386F0C21ACFD59F1B7AE.tex") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
+runsystem(rm iexec.tmp)...executed.
+runsystem(rm iexec.ret)...executed.
+docshots: rendering at line no. 32
+runsystem((cd "_docshots/snippet" && "pdflatex" -interaction=errorstopmode -halt-on-error -shell-escape C0BDB1F9A833386F0C21ACFD59F1B7AE.tex) > _docshots/snippet/C0BDB1F9A833386F0C21ACFD59F1B7AE.stdout 2>&1; /bin/echo -n $?% >_docshots/snippet/C0BDB1F9A833386F0C21ACFD59F1B7AE.ret)...executed.
+runsystem(("pdfcrop" --gscmd "gs" --margins 0 "_docshots/snippet/C0BDB1F9A833386F0C21ACFD59F1B7AE.pdf" "_docshots/snippet/C0BDB1F9A833386F0C21ACFD59F1B7AE.crop.pdf") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
+runsystem(rm iexec.tmp)...executed.
+runsystem(rm iexec.ret)...executed.
+docshots: the PDF is ready from line no. 32
+<_docshots/snippet/C0BDB1F9A833386F0C21ACFD59F1B7AE.crop.pdf, id=6, 159.59625pt x 577.15625pt>
+File: _docshots/snippet/C0BDB1F9A833386F0C21ACFD59F1B7AE.crop.pdf Graphic file (type pdf)
+<use _docshots/snippet/C0BDB1F9A833386F0C21ACFD59F1B7AE.crop.pdf>
+Package pdftex.def Info: _docshots/snippet/C0BDB1F9A833386F0C21ACFD59F1B7AE.crop.pdf  used on input line ....
+(pdftex.def)             Requested size: 103.50105pt x 374.29286pt.
+[1
+ <./_docshots/snippet/6E11CC1997D30A6656B18B0C776612DD.crop.pdf>]

--- a/testfiles/snippet.xetex.tlg
+++ b/testfiles/snippet.xetex.tlg
@@ -1,0 +1,37 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+runsystem((perl -MFile::Copy -e "copy(shift,shift) or die q(cannot copy)" "_docshots-xe/snippet/docshots-temp.tex" "_docshots-xe/snippet/6E11CC1997D30A6656B18B0C776612DD.tex") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
+runsystem(rm iexec.tmp)...executed.
+runsystem(rm iexec.ret)...executed.
+docshots: rendering at line no. 16
+runsystem((cd "_docshots-xe/snippet" && "pdflatex" -interaction=errorstopmode -halt-on-error -shell-escape 6E11CC1997D30A6656B18B0C776612DD.tex) > _docshots-xe/snippet/6E11CC1997D30A6656B18B0C776612DD.stdout 2>&1; /bin/echo -n $?% >_docshots-xe/snippet/6E11CC1997D30A6656B18B0C776612DD.ret)...executed.
+runsystem(("pdfcrop" --gscmd "gs" --margins 0 "_docshots-xe/snippet/6E11CC1997D30A6656B18B0C776612DD.pdf" "_docshots-xe/snippet/6E11CC1997D30A6656B18B0C776612DD.crop.pdf") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
+runsystem(rm iexec.tmp)...executed.
+runsystem(rm iexec.ret)...executed.
+docshots: the PDF is ready from line no. 16
+File: _docshots-xe/snippet/6E11CC1997D30A6656B18B0C776612DD.crop.pdf Graphic file (type pdf)
+<use _docshots-xe/snippet/6E11CC1997D30A6656B18B0C776612DD.crop.pdf>
+runsystem((perl -MFile::Copy -e "copy(shift,shift) or die q(cannot copy)" "_docshots-xe/snippet/docshots-temp.tex" "_docshots-xe/snippet/6BC193BC30DAEA956E52AECAFFE6CDA2.tex") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
+runsystem(rm iexec.tmp)...executed.
+runsystem(rm iexec.ret)...executed.
+docshots: rendering at line no. 24
+runsystem((cd "_docshots-xe/snippet" && "pdflatex" -interaction=errorstopmode -halt-on-error -shell-escape 6BC193BC30DAEA956E52AECAFFE6CDA2.tex) > _docshots-xe/snippet/6BC193BC30DAEA956E52AECAFFE6CDA2.stdout 2>&1; /bin/echo -n $?% >_docshots-xe/snippet/6BC193BC30DAEA956E52AECAFFE6CDA2.ret)...executed.
+runsystem(("pdfcrop" --gscmd "gs" --margins 0 "_docshots-xe/snippet/6BC193BC30DAEA956E52AECAFFE6CDA2.pdf" "_docshots-xe/snippet/6BC193BC30DAEA956E52AECAFFE6CDA2.crop.pdf") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
+runsystem(rm iexec.tmp)...executed.
+runsystem(rm iexec.ret)...executed.
+docshots: the PDF is ready from line no. 24
+File: _docshots-xe/snippet/6BC193BC30DAEA956E52AECAFFE6CDA2.crop.pdf Graphic file (type pdf)
+<use _docshots-xe/snippet/6BC193BC30DAEA956E52AECAFFE6CDA2.crop.pdf>
+runsystem((perl -MFile::Copy -e "copy(shift,shift) or die q(cannot copy)" "_docshots-xe/snippet/docshots-temp.tex" "_docshots-xe/snippet/C0BDB1F9A833386F0C21ACFD59F1B7AE.tex") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
+runsystem(rm iexec.tmp)...executed.
+runsystem(rm iexec.ret)...executed.
+docshots: rendering at line no. 32
+runsystem((cd "_docshots-xe/snippet" && "pdflatex" -interaction=errorstopmode -halt-on-error -shell-escape C0BDB1F9A833386F0C21ACFD59F1B7AE.tex) > _docshots-xe/snippet/C0BDB1F9A833386F0C21ACFD59F1B7AE.stdout 2>&1; /bin/echo -n $?% >_docshots-xe/snippet/C0BDB1F9A833386F0C21ACFD59F1B7AE.ret)...executed.
+runsystem(("pdfcrop" --gscmd "gs" --margins 0 "_docshots-xe/snippet/C0BDB1F9A833386F0C21ACFD59F1B7AE.pdf" "_docshots-xe/snippet/C0BDB1F9A833386F0C21ACFD59F1B7AE.crop.pdf") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
+runsystem(rm iexec.tmp)...executed.
+runsystem(rm iexec.ret)...executed.
+docshots: the PDF is ready from line no. 32
+File: _docshots-xe/snippet/C0BDB1F9A833386F0C21ACFD59F1B7AE.crop.pdf Graphic file (type pdf)
+<use _docshots-xe/snippet/C0BDB1F9A833386F0C21ACFD59F1B7AE.crop.pdf>
+[1
+]


### PR DESCRIPTION
This adds a `snippet` option that controls where the verbatim source sits relative to its PDF snapshot. It takes `left`, `right`, or `none`: the source goes on either side of the snapshot, or is dropped entirely so only the snapshot shows. It works both as a package option and, per docshot, through a new `\docshotSnippet` command that overrides the package-wide default for the docshot right after it. An unknown value stops the run with an error.

Issue #18 asked for two things: letting the reader pick which column the code lives in, and hiding the code to show only the result. A single option with three values covers both without adding more knobs.

The default stays `right`, so existing documents render exactly as before. There is a new regression test with saved logs for pdftex, luatex, and xetex.

Closes #18