### PR TITLE
Pass docshot options via the environment's optional argument

### DIFF
--- a/docshots.dtx
+++ b/docshots.dtx
@@ -379,15 +379,18 @@ Hello, world!
 
 % \section{Fine-tuning Options}
 
-% \DescribeMacro{\docshotOptions}
-% By default, the verbatim text is rendered by means of the |\VerbatimInput| command with
-% no options. Additional options may be supplied via the |\docshotOptions| command:
+% \DescribeEnv{docshot}
+% \changes{0.6.0}{2026/07/16}{The environment gains an optional argument that carries the per-docshot settings, replacing the docshotSnippet, docshotOptions, docshotAfter, and docshotPrerequisite commands.}
+% Every |docshot| environment accepts an optional argument, in which per-docshot
+% settings are supplied as a comma-separated list of |key=value| pairs. Four keys
+% are recognised: |snippet|, |options|, |after|, and |prerequisite|. Each applies
+% solely to the environment that carries it, leaving the defaults intact for the
+% docshots that follow:
 %\iffalse
 %<*verb>
 %\fi
 \begin{verbatim}
-\docshotOptions{firstline=4}
-\begin{docshot}
+\begin{docshot}[snippet=left, options={firstline=4}]
 ...
 \end{docshot}
 \end{verbatim}
@@ -395,20 +398,14 @@ Hello, world!
 %</verb>
 %\fi
 
-% The options are cleared upon the first rendering of a docshot.
-
-% \DescribeMacro{\docshotSnippet}
-% \changes{0.6.0}{2026/07/16}{The command is added to override the "snippet" placement of a single docshot.}
-% The package-wide |snippet| option may be overridden for a single docshot by
-% means of the |\docshotSnippet| command, which likewise accepts |left|,
-% |right|, or |none| and applies solely to the |docshot| that immediately
-% follows it:
+% \DescribeMacro{snippet}
+% The |snippet| key overrides the package-wide |snippet| option for a single
+% docshot, accepting |left|, |right|, or |none|:
 %\iffalse
 %<*verb>
 %\fi
 \begin{verbatim}
-\docshotSnippet{none}
-\begin{docshot}
+\begin{docshot}[snippet=none]
 ...
 \end{docshot}
 \end{verbatim}
@@ -416,25 +413,32 @@ Hello, world!
 %</verb>
 %\fi
 
-% \section{Prerequisites}
-
-% \DescribeMacro{\docshotPrerequisite}
-% \changes{0.0.3}{2022/10/14}{The command is added to enable copying of supplementary files into the directory where docshot snippets are processed.}
-% Whenever certain files are required to be present alongside the |.tex| snippet during
-% rendering by |pdflatex|, the |\docshotPrerequisite| command may be employed, accepting
-% a single mandatory argument. The argument denotes the name of a file to be copied from
-% the current directory to the temporary directory in which all snippets are rendered. The
-% command may appear either in the body of the document or in the preamble---the placement is
-% immaterial, provided that it precedes the docshot which requires the prerequisite. For example:
+% \DescribeMacro{options}
+% By default, the verbatim text is rendered by means of the |\VerbatimInput|
+% command with no options. Additional options may be supplied through the
+% |options| key:
 %\iffalse
 %<*verb>
 %\fi
 \begin{verbatim}
-\documentclass{article}
-\usepackage{docshots}
-\docshotPrerequisite{duck.jpg}
-\begin{document}
-\begin{docshot}
+\begin{docshot}[options={firstline=4}]
+...
+\end{docshot}
+\end{verbatim}
+%\iffalse
+%</verb>
+%\fi
+
+% \DescribeMacro{prerequisite}
+% Whenever a file is required to be present alongside the |.tex| snippet during
+% rendering by |pdflatex|, the |prerequisite| key names a file to be copied from
+% the current directory to the temporary directory in which all snippets are
+% rendered. The key may be repeated for several files:
+%\iffalse
+%<*verb>
+%\fi
+\begin{verbatim}
+\begin{docshot}[prerequisite=duck.jpg]
   \documentclass{article}
   \usepackage{graphicx}
   \pagestyle{empty}
@@ -443,27 +447,21 @@ Hello, world!
     \includegraphics[width=2in]{duck.jpg}
   \end{document}
 \end{docshot}
-\end{document}
 \end{verbatim}
 %\iffalse
 %</verb>
 %\fi
 
-% \DescribeMacro{\docshotAfter}
+% \DescribeMacro{after}
 % Should some action be required after each |pdflatex| run of a docshot, the
-% |\docshotAfter| command may be placed immediately before the |docshot| environment. For example, when a bibliography file is to remain
-% available to every snippet and \href{https://ctan.org/pkg/biber}{biber} is to be invoked
-% on each in order to process citations:
+% |after| key supplies the command to run. For example, when a bibliography is to
+% remain available to a snippet and \href{https://ctan.org/pkg/biber}{biber} is
+% to be invoked on it in order to process citations:
 %\iffalse
 %<*verb>
 %\fi
 \begin{verbatim}
-\documentclass{article}
-\usepackage{docshots}
-\docshotPrerequisite{main.bib}
-\begin{document}
-\docshotAfter{biber $2}
-\begin{docshot}
+\begin{docshot}[prerequisite=main.bib, after={biber $2}]
   \documentclass{acmart}
   \usepackage[natbib=true]{biblatex}
   \addbibresource{main.bib}
@@ -473,22 +471,17 @@ Hello, world!
     \printbibliography
   \end{document}
 \end{docshot}
-\end{document}
 \end{verbatim}
 %\iffalse
 %</verb>
 %\fi
-% The script supplied as the first argument of |\docshotAfter| receives
-% three arguments at runtime:
+% The command supplied to the |after| key receives three arguments at runtime:
 % \begin{description}\setlength\itemsep{0em}
 % \item[|\$1|] the cycle of |pdflatex| processing (1, 2, ...),
 % \item[|\$2|] the hash of the snippet,
 % \item[|\$3|] the name of the |.tex| file.
 % \end{description}
-% |$3| is, in essence, |$2| with an appended |.tex| suffix. |\docshotAfter|
-% applies solely to the first |docshot| environment that follows it; |\docshotAfter|
-% must therefore be specified before every |docshot| in which such post-processing
-% is desired.
+% |$3| is, in essence, |$2| with an appended |.tex| suffix.
 
 % \StopEventually{}
 
@@ -533,7 +526,7 @@ Hello, world!
 % We also detect Windows, in order to pick the right default for Ghostscript,
 % the right file separator for shell commands (a backslash, since |cmd.exe|
 % rejects forward slashes in redirection targets), and an expanding variant of
-% the string-replacement command for later use in \docshotAfter:
+% the string-replacement command for later use by the |after| key:
 % \changes{0.5.0}{2026/07/13}{Windows compatibility: file operations go through Perl, and the "gs" default becomes "gswin64c" on Windows.}
 %    \begin{macrocode}
 \RequirePackage{pgfopts}
@@ -656,13 +649,65 @@ Hello, world!
 %    \end{macrocode}
 % \end{macro}
 
+% \begin{macro}{\docshots@prereq}
+% \changes{0.0.3}{2022/10/14}{New supplementary command added to copy prerequisite files into the rendering directory.}
+% Then, we define an internal command that copies a prerequisite file from the
+% current directory into the temporary one, so that |pdflatex| finds it during
+% rendering:
+%    \begin{macrocode}
+\makeatletter
+\newcommand\docshots@prereq[1]{%
+  \iexec[\docshots@log,quiet]{perl -MFile::Copy -e "copy(shift,shift) or die q(cannot copy)"
+    "#1" "\docshots@tmpdir/\jobname/#1"}%
+  \message{docshots: File '#1' copied to
+    '\docshots@tmpdir/\jobname/#1'^^J}%
+}
+%    \end{macrocode}
+% \end{macro}
+
+% Then, we register the keys accepted by the optional argument of the |docshot|
+% environment. Each stores into the same internal macro that the environment
+% reads while rendering:
+%    \begin{macrocode}
+\pgfkeys{
+  /docshots/shot/.cd,
+  snippet/.store in=\docshots@thissnippet,
+  options/.store in=\docshots@opts,
+  after/.code=\edef\docshots@after{\detokenize{#1}},
+  prerequisite/.code=\docshots@prereq{#1},
+}
+%    \end{macrocode}
+
+% Then, we define the reader of that optional argument. Before peeking for the
+% |[|, we make the end-of-line active, exactly as |fancyvrb| does: an absent
+% optional argument then leaves the raw end-of-line in place, which |fancyvrb|
+% needs in order to find where the verbatim body begins. A plain |\@ifnextchar|
+% would skip that end-of-line and mislead the verbatim scanner:
+%    \begin{macrocode}
+\def\docshots@shot{%
+  \catcode`\^^M=\active%
+  \@ifnextchar[%]
+    {\catcode`\^^M=5 \docshots@grab}%
+    {\catcode`\^^M=5 \docshots@begin}}
+\def\docshots@grab[#1]{\pgfkeys{/docshots/shot/.cd,#1}\docshots@begin}
+\def\docshots@begin{\VerbatimEnvironment\begin{VerbatimOut}
+  {\docshots@tmpdir/\jobname/docshots-temp.tex}}
+\makeatother
+%    \end{macrocode}
+
 % \begin{macro}{docshot}
-% Then, we define |docshot| environment:
+% \changes{0.6.0}{2026/07/16}{The environment gains an optional argument carrying per-docshot settings; the commands docshotSnippet, docshotOptions, docshotAfter, and docshotPrerequisite are removed in its favour.}
+% Then, we define the |docshot| environment. Its optional argument carries the
+% per-docshot settings (|snippet|, |options|, |after|, and |prerequisite|),
+% which we parse under normal catcodes, before the body is captured verbatim.
+% The defaults are set locally, so that each docshot starts afresh and no
+% setting leaks into the next:
 %    \begin{macrocode}
 \makeatletter
 \newenvironment{docshot}
-{\VerbatimEnvironment\begin{VerbatimOut}
-  {\docshots@tmpdir/\jobname/docshots-temp.tex}}
+{\let\docshots@thissnippet\docshots@snippet%
+ \def\docshots@opts{}%
+ \docshots@shot}
 {\end{VerbatimOut}%
 %    \end{macrocode}
 % If we are in |dtx| mode, leading percent characters must be removed. The
@@ -702,7 +747,7 @@ Hello, world!
         \message{docshots: pdflatex run no.\n^^J}%
       \fi%
 %    \end{macrocode}
-% If a post-processing command was registered by \docshotAfter, we substitute
+% If a post-processing command was registered by the |after| key, we substitute
 % its |$1|, |$2|, and |$3| placeholders and execute it. There is no shell script
 % and no |chmod|, so the mechanism works on Windows too:
 %    \begin{macrocode}
@@ -713,7 +758,6 @@ Hello, world!
             \docshots@aftersh}%
         \endgroup%
       \fi}}%
-  \global\let\docshots@after\@undefined%
 %    \end{macrocode}
 % If a cropped version of the PDF with the required name already exists, we ignore this step.
 % Otherwise, we ask |pdfcrop| to crop the PDF:
@@ -735,16 +779,13 @@ Hello, world!
       \fi}%
   \message{docshots: the PDF is ready from line no. \the\inputlineno^^J}%
 %    \end{macrocode}
-% Finally, we render the content. When no per-docshot placement was requested
-% via \docshotSnippet, we inherit the package-wide |snippet| setting. The
-% snapshot is a framed image, and the source is a top-aligned minipage; we
-% keep each in a macro of its own, so that either may precede the other:
+% Finally, we render the content. The placement was resolved by the optional
+% argument, defaulting to the package-wide |snippet| setting. The snapshot is a
+% framed image, and the source is a top-aligned minipage; we keep each in a
+% macro of its own, so that either may precede the other:
 %    \begin{macrocode}
   \begingroup%
   \par%
-  \ifdefined\docshots@thissnippet\else%
-    \let\docshots@thissnippet\docshots@snippet%
-  \fi%
   \def\docshots@image{\tikz[baseline=(a.north)]
     \node (a) [draw=gray,inner sep=\docshots@margin,
       line width=.2pt]
@@ -796,63 +837,6 @@ Hello, world!
   \fi\fi\fi%
   \par%
   \endgroup%
-  \global\let\docshots@thissnippet\@undefined%
-  \docshotOptions{}%
-}
-\makeatother
-%    \end{macrocode}
-% \end{macro}
-
-% \begin{macro}{\docshotPrerequisite}
-% Then, we define |\docshotPrerequisite| command:
-%    \begin{macrocode}
-\makeatletter
-\newcommand\docshotPrerequisite[1]{
-  \iexec[\docshots@log,quiet]{perl -MFile::Copy -e "copy(shift,shift) or die q(cannot copy)"
-    "#1" "\docshots@tmpdir/\jobname/#1"}%
-  \message{docshots: File '#1' copied to
-    '\docshots@tmpdir/\jobname/#1'^^J}%
-}
-\makeatother
-%    \end{macrocode}
-% \end{macro}
-
-% \begin{macro}{\docshotAfter}
-% Then, we define |\docshotAfter| command. Rather than writing a shell script,
-% we merely remember the command as a detokenized string; the |docshot|
-% environment substitutes its placeholders and runs it after each |pdflatex|:
-% \changes{0.5.0}{2026/07/13}{The command is remembered as a string and executed directly, instead of being written to a shell script, for Windows compatibility.}
-%    \begin{macrocode}
-\makeatletter
-\newcommand\docshotAfter[1]{
-  \xdef\docshots@after{\detokenize{#1}}%
-  \message{docshots: post-processing command '\docshots@after' registered^^J}%
-}
-\makeatother
-%    \end{macrocode}
-% \end{macro}
-
-% \begin{macro}{\docshotSnippet}
-% Then, we define |\docshotSnippet| command, which overrides the |snippet|
-% placement for the single docshot that follows it:
-% \changes{0.6.0}{2026/07/16}{New command introduced to override the "snippet" placement of a single docshot.}
-%    \begin{macrocode}
-\makeatletter
-\newcommand\docshotSnippet[1]{%
-  \gdef\docshots@thissnippet{#1}%
-}
-\makeatother
-%    \end{macrocode}
-% \end{macro}
-
-% \begin{macro}{\docshotOptions}
-% Finally, we define |\docshotOptions| command:
-% \changes{0.3.0}{2022/11/10}{New command introduced to help specify custom options for verbatim environments.}
-%    \begin{macrocode}
-\makeatletter
-\gdef\docshots@opts{}
-\newcommand\docshotOptions[1]{%
-  \gdef\docshots@opts{#1}%
 }
 \makeatother
 %    \end{macrocode}

--- a/testfiles/prerequisites.luatex.tlg
+++ b/testfiles/prerequisites.luatex.tlg
@@ -4,11 +4,10 @@ runsystem((perl -MFile::Copy -e "copy(shift,shift) or die q(cannot copy)" "main.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
 docshots: File 'main.bib' copied to '_docshots-lua/prerequisites/main.bib'
-docshots: post-processing command 'biber --quiet $2' registered
 runsystem((perl -MFile::Copy -e "copy(shift,shift) or die q(cannot copy)" "_docshots-lua/prerequisites/docshots-temp.tex" "_docshots-lua/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.tex") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
-docshots: rendering at line no. 23
+docshots: rendering at line no. 20
 runsystem((cd "_docshots-lua/prerequisites" && "pdflatex" -interaction=errorstopmode -halt-on-error -shell-escape C967FB271644444EA7B8FB7FACCD8F04.tex) > _docshots-lua/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.stdout 2>&1; /bin/echo -n $?% >_docshots-lua/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.ret)...executed.
 runsystem((cd "_docshots-lua/prerequisites" && biber --quiet C967FB271644444EA7B8FB7FACCD8F04) > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
@@ -21,7 +20,7 @@ runsystem(rm iexec.ret)...executed.
 runsystem(("pdfcrop" --gscmd "gs" --margins 0 "_docshots-lua/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.pdf" "_docshots-lua/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.crop.pdf") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
-docshots: the PDF is ready from line no. 23
+docshots: the PDF is ready from line no. 20
 <_docshots-lua/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.crop.pdf, id=4, 345.29pt x 77.28876pt>
 File: _docshots-lua/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.crop.pdf Graphic file (type pdf)
 <use _docshots-lua/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.crop.pdf>

--- a/testfiles/prerequisites.lvt
+++ b/testfiles/prerequisites.lvt
@@ -8,10 +8,7 @@
 
 \START
 
-\docshotPrerequisite{main.bib}
-\docshotAfter{biber --quiet $2}
-\docshotOptions{firstline=2,lastline=8}
-\begin{docshot}
+\begin{docshot}[prerequisite=main.bib, after={biber --quiet $2}, options={firstline=2,lastline=8}]
   \documentclass[natbib=false]{article}
   \usepackage[natbib=true]{biblatex}
   \addbibresource{main.bib}

--- a/testfiles/prerequisites.tlg
+++ b/testfiles/prerequisites.tlg
@@ -4,11 +4,10 @@ runsystem((perl -MFile::Copy -e "copy(shift,shift) or die q(cannot copy)" "main.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
 docshots: File 'main.bib' copied to '_docshots/prerequisites/main.bib'
-docshots: post-processing command 'biber --quiet $2' registered
 runsystem((perl -MFile::Copy -e "copy(shift,shift) or die q(cannot copy)" "_docshots/prerequisites/docshots-temp.tex" "_docshots/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.tex") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
-docshots: rendering at line no. 23
+docshots: rendering at line no. 20
 runsystem((cd "_docshots/prerequisites" && "pdflatex" -interaction=errorstopmode -halt-on-error -shell-escape C967FB271644444EA7B8FB7FACCD8F04.tex) > _docshots/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.stdout 2>&1; /bin/echo -n $?% >_docshots/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.ret)...executed.
 runsystem((cd "_docshots/prerequisites" && biber --quiet C967FB271644444EA7B8FB7FACCD8F04) > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
@@ -21,7 +20,7 @@ runsystem(rm iexec.ret)...executed.
 runsystem(("pdfcrop" --gscmd "gs" --margins 0 "_docshots/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.pdf" "_docshots/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.crop.pdf") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
-docshots: the PDF is ready from line no. 23
+docshots: the PDF is ready from line no. 20
 <_docshots/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.crop.pdf, id=4, 345.29pt x 77.28876pt>
 File: _docshots/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.crop.pdf Graphic file (type pdf)
 <use _docshots/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.crop.pdf>

--- a/testfiles/prerequisites.xetex.tlg
+++ b/testfiles/prerequisites.xetex.tlg
@@ -4,11 +4,10 @@ runsystem((perl -MFile::Copy -e "copy(shift,shift) or die q(cannot copy)" "main.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
 docshots: File 'main.bib' copied to '_docshots-xe/prerequisites/main.bib'
-docshots: post-processing command 'biber --quiet $2' registered
 runsystem((perl -MFile::Copy -e "copy(shift,shift) or die q(cannot copy)" "_docshots-xe/prerequisites/docshots-temp.tex" "_docshots-xe/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.tex") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
-docshots: rendering at line no. 23
+docshots: rendering at line no. 20
 runsystem((cd "_docshots-xe/prerequisites" && "pdflatex" -interaction=errorstopmode -halt-on-error -shell-escape C967FB271644444EA7B8FB7FACCD8F04.tex) > _docshots-xe/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.stdout 2>&1; /bin/echo -n $?% >_docshots-xe/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.ret)...executed.
 runsystem((cd "_docshots-xe/prerequisites" && biber --quiet C967FB271644444EA7B8FB7FACCD8F04) > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
@@ -21,6 +20,6 @@ runsystem(rm iexec.ret)...executed.
 runsystem(("pdfcrop" --gscmd "gs" --margins 0 "_docshots-xe/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.pdf" "_docshots-xe/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.crop.pdf") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
-docshots: the PDF is ready from line no. 23
+docshots: the PDF is ready from line no. 20
 File: _docshots-xe/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.crop.pdf Graphic file (type pdf)
 <use _docshots-xe/prerequisites/C967FB271644444EA7B8FB7FACCD8F04.crop.pdf>

--- a/testfiles/snippet.luatex.tlg
+++ b/testfiles/snippet.luatex.tlg
@@ -17,12 +17,12 @@ Package luatex.def Info: _docshots-lua/snippet/6E11CC1997D30A6656B18B0C776612DD.
 runsystem((perl -MFile::Copy -e "copy(shift,shift) or die q(cannot copy)" "_docshots-lua/snippet/docshots-temp.tex" "_docshots-lua/snippet/6BC193BC30DAEA956E52AECAFFE6CDA2.tex") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
-docshots: rendering at line no. 24
+docshots: rendering at line no. 23
 runsystem((cd "_docshots-lua/snippet" && "pdflatex" -interaction=errorstopmode -halt-on-error -shell-escape 6BC193BC30DAEA956E52AECAFFE6CDA2.tex) > _docshots-lua/snippet/6BC193BC30DAEA956E52AECAFFE6CDA2.stdout 2>&1; /bin/echo -n $?% >_docshots-lua/snippet/6BC193BC30DAEA956E52AECAFFE6CDA2.ret)...executed.
 runsystem(("pdfcrop" --gscmd "gs" --margins 0 "_docshots-lua/snippet/6BC193BC30DAEA956E52AECAFFE6CDA2.pdf" "_docshots-lua/snippet/6BC193BC30DAEA956E52AECAFFE6CDA2.crop.pdf") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
-docshots: the PDF is ready from line no. 24
+docshots: the PDF is ready from line no. 23
 <_docshots-lua/snippet/6BC193BC30DAEA956E52AECAFFE6CDA2.crop.pdf, id=5, 159.59625pt x 578.16pt>
 File: _docshots-lua/snippet/6BC193BC30DAEA956E52AECAFFE6CDA2.crop.pdf Graphic file (type pdf)
 <use _docshots-lua/snippet/6BC193BC30DAEA956E52AECAFFE6CDA2.crop.pdf>
@@ -31,12 +31,12 @@ Package luatex.def Info: _docshots-lua/snippet/6BC193BC30DAEA956E52AECAFFE6CDA2.
 runsystem((perl -MFile::Copy -e "copy(shift,shift) or die q(cannot copy)" "_docshots-lua/snippet/docshots-temp.tex" "_docshots-lua/snippet/C0BDB1F9A833386F0C21ACFD59F1B7AE.tex") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
-docshots: rendering at line no. 32
+docshots: rendering at line no. 30
 runsystem((cd "_docshots-lua/snippet" && "pdflatex" -interaction=errorstopmode -halt-on-error -shell-escape C0BDB1F9A833386F0C21ACFD59F1B7AE.tex) > _docshots-lua/snippet/C0BDB1F9A833386F0C21ACFD59F1B7AE.stdout 2>&1; /bin/echo -n $?% >_docshots-lua/snippet/C0BDB1F9A833386F0C21ACFD59F1B7AE.ret)...executed.
 runsystem(("pdfcrop" --gscmd "gs" --margins 0 "_docshots-lua/snippet/C0BDB1F9A833386F0C21ACFD59F1B7AE.pdf" "_docshots-lua/snippet/C0BDB1F9A833386F0C21ACFD59F1B7AE.crop.pdf") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
-docshots: the PDF is ready from line no. 32
+docshots: the PDF is ready from line no. 30
 <_docshots-lua/snippet/C0BDB1F9A833386F0C21ACFD59F1B7AE.crop.pdf, id=6, 159.59625pt x 577.15625pt>
 File: _docshots-lua/snippet/C0BDB1F9A833386F0C21ACFD59F1B7AE.crop.pdf Graphic file (type pdf)
 <use _docshots-lua/snippet/C0BDB1F9A833386F0C21ACFD59F1B7AE.crop.pdf>

--- a/testfiles/snippet.lvt
+++ b/testfiles/snippet.lvt
@@ -15,16 +15,14 @@
 \end{document}
 \end{docshot}
 
-\docshotSnippet{right}
-\begin{docshot}
+\begin{docshot}[snippet=right]
 \documentclass{article}
 \begin{document}
   Right snippet.
 \end{document}
 \end{docshot}
 
-\docshotSnippet{none}
-\begin{docshot}
+\begin{docshot}[snippet=none]
 \documentclass{article}
 \begin{document}
   No snippet.

--- a/testfiles/snippet.tlg
+++ b/testfiles/snippet.tlg
@@ -17,12 +17,12 @@ Package pdftex.def Info: _docshots/snippet/6E11CC1997D30A6656B18B0C776612DD.crop
 runsystem((perl -MFile::Copy -e "copy(shift,shift) or die q(cannot copy)" "_docshots/snippet/docshots-temp.tex" "_docshots/snippet/6BC193BC30DAEA956E52AECAFFE6CDA2.tex") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
-docshots: rendering at line no. 24
+docshots: rendering at line no. 23
 runsystem((cd "_docshots/snippet" && "pdflatex" -interaction=errorstopmode -halt-on-error -shell-escape 6BC193BC30DAEA956E52AECAFFE6CDA2.tex) > _docshots/snippet/6BC193BC30DAEA956E52AECAFFE6CDA2.stdout 2>&1; /bin/echo -n $?% >_docshots/snippet/6BC193BC30DAEA956E52AECAFFE6CDA2.ret)...executed.
 runsystem(("pdfcrop" --gscmd "gs" --margins 0 "_docshots/snippet/6BC193BC30DAEA956E52AECAFFE6CDA2.pdf" "_docshots/snippet/6BC193BC30DAEA956E52AECAFFE6CDA2.crop.pdf") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
-docshots: the PDF is ready from line no. 24
+docshots: the PDF is ready from line no. 23
 <_docshots/snippet/6BC193BC30DAEA956E52AECAFFE6CDA2.crop.pdf, id=5, 159.59625pt x 578.16pt>
 File: _docshots/snippet/6BC193BC30DAEA956E52AECAFFE6CDA2.crop.pdf Graphic file (type pdf)
 <use _docshots/snippet/6BC193BC30DAEA956E52AECAFFE6CDA2.crop.pdf>
@@ -31,12 +31,12 @@ Package pdftex.def Info: _docshots/snippet/6BC193BC30DAEA956E52AECAFFE6CDA2.crop
 runsystem((perl -MFile::Copy -e "copy(shift,shift) or die q(cannot copy)" "_docshots/snippet/docshots-temp.tex" "_docshots/snippet/C0BDB1F9A833386F0C21ACFD59F1B7AE.tex") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
-docshots: rendering at line no. 32
+docshots: rendering at line no. 30
 runsystem((cd "_docshots/snippet" && "pdflatex" -interaction=errorstopmode -halt-on-error -shell-escape C0BDB1F9A833386F0C21ACFD59F1B7AE.tex) > _docshots/snippet/C0BDB1F9A833386F0C21ACFD59F1B7AE.stdout 2>&1; /bin/echo -n $?% >_docshots/snippet/C0BDB1F9A833386F0C21ACFD59F1B7AE.ret)...executed.
 runsystem(("pdfcrop" --gscmd "gs" --margins 0 "_docshots/snippet/C0BDB1F9A833386F0C21ACFD59F1B7AE.pdf" "_docshots/snippet/C0BDB1F9A833386F0C21ACFD59F1B7AE.crop.pdf") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
-docshots: the PDF is ready from line no. 32
+docshots: the PDF is ready from line no. 30
 <_docshots/snippet/C0BDB1F9A833386F0C21ACFD59F1B7AE.crop.pdf, id=6, 159.59625pt x 577.15625pt>
 File: _docshots/snippet/C0BDB1F9A833386F0C21ACFD59F1B7AE.crop.pdf Graphic file (type pdf)
 <use _docshots/snippet/C0BDB1F9A833386F0C21ACFD59F1B7AE.crop.pdf>

--- a/testfiles/snippet.xetex.tlg
+++ b/testfiles/snippet.xetex.tlg
@@ -14,23 +14,23 @@ File: _docshots-xe/snippet/6E11CC1997D30A6656B18B0C776612DD.crop.pdf Graphic fil
 runsystem((perl -MFile::Copy -e "copy(shift,shift) or die q(cannot copy)" "_docshots-xe/snippet/docshots-temp.tex" "_docshots-xe/snippet/6BC193BC30DAEA956E52AECAFFE6CDA2.tex") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
-docshots: rendering at line no. 24
+docshots: rendering at line no. 23
 runsystem((cd "_docshots-xe/snippet" && "pdflatex" -interaction=errorstopmode -halt-on-error -shell-escape 6BC193BC30DAEA956E52AECAFFE6CDA2.tex) > _docshots-xe/snippet/6BC193BC30DAEA956E52AECAFFE6CDA2.stdout 2>&1; /bin/echo -n $?% >_docshots-xe/snippet/6BC193BC30DAEA956E52AECAFFE6CDA2.ret)...executed.
 runsystem(("pdfcrop" --gscmd "gs" --margins 0 "_docshots-xe/snippet/6BC193BC30DAEA956E52AECAFFE6CDA2.pdf" "_docshots-xe/snippet/6BC193BC30DAEA956E52AECAFFE6CDA2.crop.pdf") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
-docshots: the PDF is ready from line no. 24
+docshots: the PDF is ready from line no. 23
 File: _docshots-xe/snippet/6BC193BC30DAEA956E52AECAFFE6CDA2.crop.pdf Graphic file (type pdf)
 <use _docshots-xe/snippet/6BC193BC30DAEA956E52AECAFFE6CDA2.crop.pdf>
 runsystem((perl -MFile::Copy -e "copy(shift,shift) or die q(cannot copy)" "_docshots-xe/snippet/docshots-temp.tex" "_docshots-xe/snippet/C0BDB1F9A833386F0C21ACFD59F1B7AE.tex") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
-docshots: rendering at line no. 32
+docshots: rendering at line no. 30
 runsystem((cd "_docshots-xe/snippet" && "pdflatex" -interaction=errorstopmode -halt-on-error -shell-escape C0BDB1F9A833386F0C21ACFD59F1B7AE.tex) > _docshots-xe/snippet/C0BDB1F9A833386F0C21ACFD59F1B7AE.stdout 2>&1; /bin/echo -n $?% >_docshots-xe/snippet/C0BDB1F9A833386F0C21ACFD59F1B7AE.ret)...executed.
 runsystem(("pdfcrop" --gscmd "gs" --margins 0 "_docshots-xe/snippet/C0BDB1F9A833386F0C21ACFD59F1B7AE.pdf" "_docshots-xe/snippet/C0BDB1F9A833386F0C21ACFD59F1B7AE.crop.pdf") > iexec.tmp 2>&1; /bin/echo -n $?% >iexec.ret)...executed.
 runsystem(rm iexec.tmp)...executed.
 runsystem(rm iexec.ret)...executed.
-docshots: the PDF is ready from line no. 32
+docshots: the PDF is ready from line no. 30
 File: _docshots-xe/snippet/C0BDB1F9A833386F0C21ACFD59F1B7AE.crop.pdf Graphic file (type pdf)
 <use _docshots-xe/snippet/C0BDB1F9A833386F0C21ACFD59F1B7AE.crop.pdf>
 [1


### PR DESCRIPTION
This makes every `docshot` environment take an optional argument of `key=value` pairs — `snippet`, `options`, `after`, and `prerequisite` — so a docshot is configured on its own `\begin` line rather than through commands placed before it. The argument is parsed before the body is captured verbatim, and the settings are stored locally, so nothing leaks into the next docshot and the reset dance is gone.

The one tricky part is that fancyvrb reads the verbatim body line by line and needs the raw end-of-line after `\begin{docshot}` to survive. A plain `\@ifnextchar` skips it, which breaks the scanner, so the reader makes the end-of-line active before peeking for the `[`, exactly as fancyvrb does internally. An absent argument then leaves the line boundary in place.

This removes the four `\docshotSnippet`, `\docshotOptions`, `\docshotAfter`, and `\docshotPrerequisite` commands, so it is a breaking change. The `snippet` and `prerequisites` regression tests are rewritten to the new syntax with fresh goldens for all three engines, and I checked the left/right/none layouts render as before. Closes #69.